### PR TITLE
DCMAW-8317

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM gradle:8.6.0-jdk17-alpine@sha265:efc3f440f6a8685bedd93e888bbda0ba82afc4b3
+FROM gradle:8.6.0-jdk17-alpine@sha256:87f40d50d0015236f5aa95d13399508d70e44bc3d97f3bb80efe9a942957825b
 
 WORKDIR /app
 COPY src/ src/
-COPY build.gradle settings.gradle gradlew gradlew.bat config.yaml ./
+COPY build.gradle settings.gradle gradlew gradlew.bat config.yml ./
 COPY gradle/ gradle/
 RUN ./gradlew
 


### PR DESCRIPTION

### What changed

Introduces the Dockerfile that builds and runs the Java service. This has been shown to both build and run locally.

### Why did it change

This file is necessary, in order for us to deploy this service to ECR and eventually use containerised deployment with ECS services

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DCMAW-8317](https://govukverify.atlassian.net/browse/DCMAW-8317)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other consideration if needed -->

[DCMAW-8317]: https://govukverify.atlassian.net/browse/DCMAW-8317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ