### PR TITLE
DCMAW 8315: Deploy template for ECS and related resources

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -402,9 +402,9 @@ Resources:
   WalletBEECSServiceTaskDefinition:
     Type: 'AWS::ECS::TaskDefinition'
     Properties:
-      ContainerDefinitions:
+      ContainerDefinitions: CONTAINER-IMAGE-PLACEHOLDER
         - Essential: true
-          Image: 671524980203.dkr.ecr.eu-west-2.amazonaws.com/wallet-cred-issuer-be-ecr-containerrepository-ta87rf6hloli:chris_test_image
+          Image: CONTAINER
           Name: app
           Environment:
             - Name: SIGNING_KEY_ALIAS


### PR DESCRIPTION

### What changed

This PR introduces the deployment template for the Backend example credential issuer stub. Key resources include:
- ECS and related resources
- Https API gateway and custom domain
- Loadbalancer
- KMS asynchronous encryption key

### Why did it change

This template is required for deploying the resources necessary to spin up a ECS container, from our Docker image that has been pushed to our ECR repository.
The LoadBalancer associates the API Gateway with a custom domain name and our ECS services.
This follows a standard architectural pattern for containerised deployment in the Mobile pod.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DCMAW-8315](https://govukverify.atlassian.net/browse/DCMAW-8315)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other consideration if needed -->

[DCMAW-8315]: https://govukverify.atlassian.net/browse/DCMAW-8315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ