### PR TITLE
log credentialOffer signing and saving exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ build
 dist
 .idea
 *.toml
+.vscode/
+bin/

--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential_offer/CredentialOfferResource.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential_offer/CredentialOfferResource.java
@@ -9,6 +9,8 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.di.mobile.wallet.cri.models.CredentialOfferCacheItem;
 import uk.gov.di.mobile.wallet.cri.services.ConfigurationService;
 import uk.gov.di.mobile.wallet.cri.services.data_storage.DataStore;
@@ -26,6 +28,8 @@ public class CredentialOfferResource {
     private final CredentialOfferService credentialOfferService;
     private final ConfigurationService configurationService;
     private final DataStore dataStore;
+
+    private static Logger logger = LoggerFactory.getLogger(CredentialOfferResource.class);
 
     public CredentialOfferResource(
             CredentialOfferService credentialOfferService,
@@ -49,6 +53,9 @@ public class CredentialOfferResource {
         try {
             credentialOffer = credentialOfferService.buildCredentialOffer(credentialIdentifier);
         } catch (SigningException exception) {
+            logger.error(
+                    "failed to sign credential offer for walletSubjectID: {} , documentID: {}",
+                    exception);
             return buildFailResponse().build();
         }
 
@@ -57,6 +64,9 @@ public class CredentialOfferResource {
                     new CredentialOfferCacheItem(
                             credentialIdentifier, documentId, walletSubjectId));
         } catch (DataStoreException exception) {
+            logger.error(
+                    "failed to save credential offer for walletSubjectID: {} , documentID: {}",
+                    exception);
             return buildFailResponse().build();
         }
 


### PR DESCRIPTION
## Proposed changes
- Add logging of signing and saving exceptions. 
- ignore files created by VsCode

### Why did it change
Without this logging the errors are hidden and debugging is very difficult. 

### Issue tracking
https://govukverify.atlassian.net/browse/DCMAW-8869

Implementation observed by @cmiddletonD and @DougsCER  yesterday while debugging issues in AWS