### PR TITLE
DCMAW-8706 WAF Association

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -612,3 +612,11 @@ Resources:
           Value: Mobile Wallet Team
         - Key: Environment
           Value: !Ref "Environment"
+
+# WAF ASSOCIATION
+
+  ExampleCredIssuerWebAclAssociation:
+      Type: AWS::WAFv2::WebACLAssociation
+      Properties:
+        ResourceArn: !Ref WalletBELoadBalancer
+        WebACLArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Security/WafArn}}"


### PR DESCRIPTION

### Why did it change

Associated the example credential issuer Loadbalancer with WAF


- [DCMAW-8706](https://govukverify.atlassian.net/browse/DCMAW-8706)

<img width="1127" alt="image" src="https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/assets/112948043/73690b5a-3b67-44cf-af01-8b647a3579d7">

[DCMAW-8706]: https://govukverify.atlassian.net/browse/DCMAW-8706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ