### PR TITLE
Correct credential API URL in metadata

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/metadata/MetadataResource.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/metadata/MetadataResource.java
@@ -31,9 +31,9 @@ public class MetadataResource {
 
             Metadata metadata =
                     metadataBuilder
-                            .setCredentialIssuer(
+                            .setCredentialIssuer(configurationService.getExampleCriUrl())
+                            .setCredentialsEndpoint(
                                     configurationService.getExampleCriUrl() + CREDENTIAL_ENDPOINT)
-                            .setCredentialsEndpoint(configurationService.getExampleCriUrl())
                             .setAuthorizationServers(configurationService.getStsStubUrl())
                             .setCredentialsSupported(CREDENTIALS_SUPPORTED_FILE_NAME)
                             .build();


### PR DESCRIPTION
## Proposed changes
Credential API URL should have /credential. credential_issuer should not.

### What changed
Change metadata builder. 
