### PR TITLE
feat(DCMAW-9032): hash credential kid

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential/CredentialService.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential/CredentialService.java
@@ -15,6 +15,7 @@ import uk.gov.di.mobile.wallet.cri.services.signing.SigningException;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 import java.util.List;
 
@@ -49,7 +50,8 @@ public class CredentialService {
                     ProofJwtValidationException,
                     ClaimMismatchException,
                     SigningException,
-                    AccessTokenValidationException {
+                    AccessTokenValidationException,
+                    NoSuchAlgorithmException {
 
         SignedJWT accessToken = accessTokenService.verifyAccessToken(bearerAccessToken);
 

--- a/src/main/java/uk/gov/di/mobile/wallet/cri/did_document/DidDocumentService.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/did_document/DidDocumentService.java
@@ -14,7 +14,6 @@ import java.util.List;
 
 public class DidDocumentService {
 
-    private static final String DID_KEY_ID_HASHING_ALGORITHM = "SHA-256";
     private static final String VERIFICATION_METHOD_TYPE = "JsonWebKey2020";
     private static final String CONTROLLER_PREFIX = "did:web:";
     private static final List<String> CONTEXT =
@@ -54,7 +53,8 @@ public class DidDocumentService {
         ECKey jwk = keyService.getPublicKey(keyAlias);
 
         String keyId = jwk.getKeyID();
-        MessageDigest messageDigest = MessageDigest.getInstance(DID_KEY_ID_HASHING_ALGORITHM);
+        String kidHashingAlgorithm = configurationService.getKeyIdHashingAlgorithm();
+        MessageDigest messageDigest = MessageDigest.getInstance(kidHashingAlgorithm);
         String hashedKeyId =
                 Hex.encodeHexString(messageDigest.digest(keyId.getBytes(StandardCharsets.UTF_8)));
 

--- a/src/main/java/uk/gov/di/mobile/wallet/cri/services/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/services/ConfigurationService.java
@@ -69,4 +69,8 @@ public class ConfigurationService extends Configuration {
     public String getLocalstackEndpoint() {
         return "http://localhost:4560";
     }
+
+    public String getKeyIdHashingAlgorithm() {
+        return "SHA-256";
+    }
 }

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialBuilderTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialBuilderTest.java
@@ -25,6 +25,7 @@ import uk.gov.di.mobile.wallet.cri.services.ConfigurationService;
 import uk.gov.di.mobile.wallet.cri.services.signing.KmsService;
 import uk.gov.di.mobile.wallet.cri.services.signing.SigningException;
 
+import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -42,6 +43,8 @@ import static org.mockito.Mockito.when;
 public class CredentialBuilderTest {
     private CredentialBuilder credentialBuilder;
     private final KmsService kmsService = mock(KmsService.class);
+    private final String HASHED_KEY_ID =
+            "78fa131d677c1ac0f172c53b47ac169a95ad0d92c38bd794a70da59032058274";
     private JsonNode DOCUMENT_DETAILS;
 
     ConfigurationService configurationService;
@@ -60,7 +63,8 @@ public class CredentialBuilderTest {
     @Test
     @DisplayName(
             "Should build the verifiable credential with the correct claims and sign it with KMS")
-    void testItReturnsCredential() throws SigningException, ParseException, JOSEException {
+    void testItReturnsCredential()
+            throws SigningException, ParseException, JOSEException, NoSuchAlgorithmException {
         SignResponse signResponse = getMockedSignResponse();
         when(kmsService.sign(any(SignRequest.class))).thenReturn(signResponse);
 
@@ -72,8 +76,7 @@ public class CredentialBuilderTest {
         assertThat(credentialBuilderReturnValue, hasProperty("credential"));
         assertThat(credential.getHeader().getAlgorithm(), equalTo(JWSAlgorithm.ES256));
         assertThat(credential.getHeader().getType(), equalTo(JOSEObjectType.JWT));
-        assertThat(
-                credential.getHeader().getKeyID(), equalTo("ff275b92-0def-4dfc-b0f6-87c96b26c6c7"));
+        assertThat(credential.getHeader().getKeyID(), equalTo(HASHED_KEY_ID));
         assertThat(
                 credential.getJWTClaimsSet().getIssuer(),
                 equalTo("urn:fdc:gov:uk:example-credential-issuer"));

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialResourceTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialResourceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.mobile.wallet.cri.services.data_storage.DataStoreException;
 import uk.gov.di.mobile.wallet.cri.services.signing.SigningException;
 
+import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -47,7 +48,8 @@ public class CredentialResourceTest {
                     AccessTokenValidationException,
                     ClaimMismatchException,
                     SigningException,
-                    ProofJwtValidationException {
+                    ProofJwtValidationException,
+                    NoSuchAlgorithmException {
         JsonNode requestBody = new ObjectMapper().readTree("{\"proof\":{\"proof_type\":\"jwt\"}}");
 
         final Response response =
@@ -70,7 +72,8 @@ public class CredentialResourceTest {
                     AccessTokenValidationException,
                     ClaimMismatchException,
                     SigningException,
-                    ProofJwtValidationException {
+                    ProofJwtValidationException,
+                    NoSuchAlgorithmException {
         JsonNode requestBody =
                 new ObjectMapper()
                         .readTree(
@@ -96,7 +99,8 @@ public class CredentialResourceTest {
                     ClaimMismatchException,
                     SigningException,
                     ProofJwtValidationException,
-                    JsonProcessingException {
+                    JsonProcessingException,
+                    NoSuchAlgorithmException {
 
         String authorizationHeader =
                 "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
@@ -127,7 +131,8 @@ public class CredentialResourceTest {
                     SigningException,
                     ProofJwtValidationException,
                     JsonProcessingException,
-                    ParseException {
+                    ParseException,
+                    NoSuchAlgorithmException {
 
         String authorizationHeader =
                 "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialServiceTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialServiceTest.java
@@ -23,6 +23,7 @@ import uk.gov.di.mobile.wallet.cri.services.data_storage.DynamoDbService;
 import uk.gov.di.mobile.wallet.cri.services.signing.SigningException;
 
 import java.net.URI;
+import java.security.NoSuchAlgorithmException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -185,7 +186,8 @@ public class CredentialServiceTest {
                     java.text.ParseException,
                     ProofJwtValidationException,
                     DataStoreException,
-                    SigningException {
+                    SigningException,
+                    NoSuchAlgorithmException {
         BearerAccessToken bearerAccessToken =
                 BearerAccessToken.parse(
                         "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjcmVkZW50aWFsX2lkZW50aWZpZXJzIjpbImNyZWRlbnRpYWxfaWRlbnRpZmllciJdLCJzdWIiOiJ0ZXN0LXdhbGxldC1zdWJqZWN0LWlkIiwiY19ub25jZSI6IjEyMzQ1In0.gXgeBUJ2d7gT2gzv-lkKXIcWcBmwxfwdivNT0p5J_Xc");
@@ -233,7 +235,8 @@ public class CredentialServiceTest {
                     ProofJwtValidationException,
                     DataStoreException,
                     SigningException,
-                    ClaimMismatchException {
+                    ClaimMismatchException,
+                    NoSuchAlgorithmException {
         BearerAccessToken bearerAccessToken =
                 BearerAccessToken.parse(
                         "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjcmVkZW50aWFsX2lkZW50aWZpZXJzIjpbImNyZWRlbnRpYWxfaWRlbnRpZmllciJdLCJzdWIiOiJ0ZXN0LXdhbGxldC1zdWJqZWN0LWlkIiwiY19ub25jZSI6IjEyMzQ1In0.gXgeBUJ2d7gT2gzv-lkKXIcWcBmwxfwdivNT0p5J_Xc");


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->

### What changed
- Hash the `kid` in the credential header using the SHA-256 hashing algorithm

![Screenshot 2024-04-30 at 10 47 56](https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/assets/85736783/fa181a7b-63cc-433e-a0bd-9025dc0312b3)

![Screenshot 2024-04-30 at 10 46 59](https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/assets/85736783/e883d9a6-5d06-4d88-899e-7bff87706bb0)
![Screenshot 2024-04-30 at 10 47 10](https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/assets/85736783/e8be8d31-cd3f-4e8d-bff2-57e19a58c2a1)

### Why did it change
 -  credential `kid` must match `kid` in the DID document (which is hashed)


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DCMAW-9032](https://govukverify.atlassian.net/browse/DCMAW-9032)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other consideration if needed -->

[DCMAW-9032]: https://govukverify.atlassian.net/browse/DCMAW-9032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ