### PR TITLE
chore(DCMAW-9365) stop making credential_identifier mandatory

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential/RequestBody.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential/RequestBody.java
@@ -14,7 +14,7 @@ public class RequestBody {
     @JsonCreator
     public RequestBody(
             @JsonProperty(value = "proof", required = true) Proof proof,
-            @JsonProperty(value = "credential_identifier", required = true)
+            @JsonProperty(value = "credential_identifier", required = false)
                     String credentialIdentifier) {
         this.proof = proof;
         this.credential_identifier = credentialIdentifier;

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialResourceTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialResourceTest.java
@@ -361,6 +361,40 @@ public class CredentialResourceTest {
                 is(new ObjectMapper().writeValueAsString(credential)));
     }
 
+    @Test
+    void shouldReturn200WhenRequestHasNoCredential_Identifiers()
+            throws DataStoreException,
+                    AccessTokenValidationException,
+                    SigningException,
+                    ProofJwtValidationException,
+                    JsonProcessingException,
+                    ParseException,
+                    NoSuchAlgorithmException,
+                    URISyntaxException,
+                    CredentialServiceException {
+        JsonNode requestBody =
+                new ObjectMapper()
+                        .readTree(
+                                "{\"proof\":{\"proof_type\":\"jwt\", \"jwt\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"}}");
+        Credential credential = getMockCredential();
+        when(credentialService.getCredential(any(SignedJWT.class), any(SignedJWT.class)))
+                .thenReturn(credential);
+
+        final Response response =
+                EXT.target("/credential")
+                        .request()
+                        .header(
+                                "Authorization",
+                                "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+                        .post(Entity.entity(requestBody, MediaType.APPLICATION_JSON));
+
+        verify(credentialService, Mockito.times(1)).getCredential(any(), any());
+        assertThat(response.getStatus(), is(200));
+        assertThat(
+                response.readEntity(String.class),
+                is(new ObjectMapper().writeValueAsString(credential)));
+    }
+
     private Credential getMockCredential() throws ParseException {
         SignedJWT credential =
                 SignedJWT.parse(


### PR DESCRIPTION
## Proposed changes
stop making credential_identifier mandatory

### Why did it change
so the apps can remove it 

### Issue tracking
1st part of https://govukverify.atlassian.net/browse/DCMAW-9365

Tested by adding a unit test. 