### PR TITLE
feat(DCMAW-9365): remove credential_identifier

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential/RequestBody.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential/RequestBody.java
@@ -8,23 +8,12 @@ public class RequestBody {
     @JsonProperty("proof")
     private Proof proof;
 
-    @JsonProperty("credential_identifier")
-    private String credential_identifier;
-
     @JsonCreator
-    public RequestBody(
-            @JsonProperty(value = "proof", required = true) Proof proof,
-            @JsonProperty(value = "credential_identifier", required = false)
-                    String credentialIdentifier) {
+    public RequestBody(@JsonProperty(value = "proof", required = true) Proof proof) {
         this.proof = proof;
-        this.credential_identifier = credentialIdentifier;
     }
 
     public Proof getProof() {
         return proof;
-    }
-
-    public String getCredentialIdentifier() {
-        return credential_identifier;
     }
 }

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialResourceTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialResourceTest.java
@@ -79,10 +79,7 @@ public class CredentialResourceTest {
                     NoSuchAlgorithmException,
                     URISyntaxException,
                     CredentialServiceException {
-        JsonNode requestBody =
-                new ObjectMapper()
-                        .readTree(
-                                "{\"credential_identifier\":\"7fb54d49-985b-4a52-be20-6d820cc8fc40\", \"proof\":{\"proof_type\":\"jwt\"}}");
+        JsonNode requestBody = new ObjectMapper().readTree("{\"proof\":{\"proof_type\":\"jwt\"}}");
 
         final Response response =
                 EXT.target("/credential")
@@ -108,9 +105,7 @@ public class CredentialResourceTest {
                     URISyntaxException,
                     CredentialServiceException {
         JsonNode requestBody =
-                new ObjectMapper()
-                        .readTree(
-                                "{\"credential_identifier\":\"7fb54d49-985b-4a52-be20-6d820cc8fc40\", \"proof_type\":\"jwt\", \"jwt\":\"testJwt\"}");
+                new ObjectMapper().readTree("{\"proof_type\":\"jwt\", \"jwt\":\"testJwt\"}");
 
         final Response response =
                 EXT.target("/credential")
@@ -138,7 +133,7 @@ public class CredentialResourceTest {
         JsonNode requestBody =
                 new ObjectMapper()
                         .readTree(
-                                "{\"credential_identifier\":\"7fb54d49-985b-4a52-be20-6d820cc8fc40\", \"invalidParam\": \"test\", \"proof\":{\"proof_type\":\"jwt\", \"jwt\": \"testJwt\"}}");
+                                "{\"invalidParam\": \"test\", \"proof\":{\"proof_type\":\"jwt\", \"jwt\": \"testJwt\"}}");
 
         final Response response =
                 EXT.target("/credential")
@@ -166,7 +161,7 @@ public class CredentialResourceTest {
         JsonNode requestBody =
                 new ObjectMapper()
                         .readTree(
-                                "{\"credential_identifier\":\"7fb54d49-985b-4a52-be20-6d820cc8fc40\", \"proof\":{\"proof_type\":\"somethingElse\", \"jwt\": \"testJwt\"}}");
+                                "{\"proof\":{\"proof_type\":\"somethingElse\", \"jwt\": \"testJwt\"}}");
 
         final Response response =
                 EXT.target("/credential")
@@ -193,8 +188,7 @@ public class CredentialResourceTest {
                     CredentialServiceException {
         JsonNode requestBody =
                 new ObjectMapper()
-                        .readTree(
-                                "{\"credential_identifier\":\"7fb54d49-985b-4a52-be20-6d820cc8fc40\", \"proof\":{\"proof_type\":\"jwt\", \"jwt\": \"testJwt\"}}");
+                        .readTree("{\"proof\":{\"proof_type\":\"jwt\", \"jwt\": \"testJwt\"}}");
 
         final Response response =
                 EXT.target("/credential")
@@ -222,7 +216,7 @@ public class CredentialResourceTest {
         JsonNode requestBody =
                 new ObjectMapper()
                         .readTree(
-                                "{\"credential_identifier\":\"7fb54d49-985b-4a52-be20-6d820cc8fc40\", \"proof\":{\"proof_type\":\"jwt\", \"jwt\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"}}");
+                                "{\"proof\":{\"proof_type\":\"jwt\", \"jwt\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"}}");
 
         final Response response =
                 EXT.target("/credential")
@@ -248,7 +242,7 @@ public class CredentialResourceTest {
         JsonNode requestBody =
                 new ObjectMapper()
                         .readTree(
-                                "{\"credential_identifier\":\"7fb54d49-985b-4a52-be20-6d820cc8fc40\", \"proof\":{\"proof_type\":\"jwt\", \"jwt\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"}}");
+                                "{\"proof\":{\"proof_type\":\"jwt\", \"jwt\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"}}");
 
         final Response response =
                 EXT.target("/credential")
@@ -276,7 +270,7 @@ public class CredentialResourceTest {
         JsonNode requestBody =
                 new ObjectMapper()
                         .readTree(
-                                "{\"credential_identifier\":\"7fb54d49-985b-4a52-be20-6d820cc8fc40\", \"proof\":{\"proof_type\":\"jwt\", \"jwt\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"}}");
+                                "{\"proof\":{\"proof_type\":\"jwt\", \"jwt\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"}}");
         doThrow(new SigningException("Some signing error", new Exception()))
                 .when(credentialService)
                 .getCredential(any(), any());
@@ -308,7 +302,7 @@ public class CredentialResourceTest {
         JsonNode requestBody =
                 new ObjectMapper()
                         .readTree(
-                                "{\"credential_identifier\":\"7fb54d49-985b-4a52-be20-6d820cc8fc40\", \"proof\":{\"proof_type\":\"jwt\", \"jwt\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"}}");
+                                "{\"proof\":{\"proof_type\":\"jwt\", \"jwt\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"}}");
         doThrow(new DataStoreException("Some database error", new Exception()))
                 .when(credentialService)
                 .getCredential(any(), any());
@@ -341,7 +335,7 @@ public class CredentialResourceTest {
         JsonNode requestBody =
                 new ObjectMapper()
                         .readTree(
-                                "{\"credential_identifier\":\"7fb54d49-985b-4a52-be20-6d820cc8fc40\", \"proof\":{\"proof_type\":\"jwt\", \"jwt\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"}}");
+                                "{\"proof\":{\"proof_type\":\"jwt\", \"jwt\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"}}");
         Credential credential = getMockCredential();
         when(credentialService.getCredential(any(SignedJWT.class), any(SignedJWT.class)))
                 .thenReturn(credential);


### PR DESCRIPTION
### What changed
- remove the `credential_identifier` property from the `/credential` request body

![Screenshot 2024-06-27 at 11 23 00](https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/assets/85736783/77705618-9cd4-4e2b-915d-ef9e1bc22866)
![Screenshot 2024-06-27 at 11 23 25](https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/assets/85736783/82b19c81-6f9e-4703-9c4f-2fcb12859251)


### Why did it change
- this property is not required and the CRI has no use for it

### Issue tracking
- [DCMAW-9365](https://govukverify.atlassian.net/browse/DCMAW-9365)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other consideration if needed -->

[DCMAW-9365]: https://govukverify.atlassian.net/browse/DCMAW-9365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ