### PR TITLE
fix: add input parameter validation to credential_offer endpoint

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential_offer/CredentialOfferResource.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential_offer/CredentialOfferResource.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.inject.Singleton;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -30,6 +32,11 @@ public class CredentialOfferResource {
     private final DataStore dataStore;
     private static final Logger LOGGER = LoggerFactory.getLogger(CredentialOfferResource.class);
 
+    private static final String WALLET_SUBJECT_ID_PATTERN =
+            "^urn:fdc:wallet\\.account\\.gov\\.uk:2024:[a-zA-Z0-9_-]{43}$";
+    private static final String DOCUMENT_ID_PATTERN = "^[a-zA-Z0-9_-]{10,50}$";
+    private static final String CREDENTIAL_TYPE_PATTERN = "^[a-zA-Z]{10,100}$";
+
     public CredentialOfferResource(
             CredentialOfferService credentialOfferService,
             ConfigurationService configurationService,
@@ -40,10 +47,14 @@ public class CredentialOfferResource {
     }
 
     @GET
+    @Produces(MediaType.APPLICATION_JSON)
     public Response getCredentialOffer(
-            @QueryParam("walletSubjectId") @NotEmpty String walletSubjectId,
-            @QueryParam("documentId") @NotEmpty String documentId,
-            @QueryParam("credentialType") @NotEmpty String credentialType)
+            @QueryParam("walletSubjectId") @NotEmpty @Pattern(regexp = WALLET_SUBJECT_ID_PATTERN)
+                    String walletSubjectId,
+            @QueryParam("documentId") @NotEmpty @Pattern(regexp = DOCUMENT_ID_PATTERN)
+                    String documentId,
+            @QueryParam("credentialType") @NotEmpty @Pattern(regexp = CREDENTIAL_TYPE_PATTERN)
+                    String credentialType)
             throws JsonProcessingException {
 
         UUID uuid = UUID.randomUUID();

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential_offer/CredentialOfferResourceTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential_offer/CredentialOfferResourceTest.java
@@ -43,7 +43,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class CredentialOfferResourceTest {
 
-    private static final String WALLET_SUBJECT_ID = "mock-wallet-subject-id";
+    private static final String WALLET_SUBJECT_ID =
+            "urn:fdc:wallet.account.gov.uk:2024:DtPT8x-dp_73tnlY3KNTiCitziN9GEherD16bqxNt9i";
     private static final String DOCUMENT_ID = "mock-document-id";
     private static final String CREDENTIAL_TYPE = "TestCredentialType";
     private static final String KEY_ID = "ff275b92-0def-4dfc-b0f6-87c96b26c6c7";
@@ -111,6 +112,45 @@ public class CredentialOfferResourceTest {
 
         Mockito.verify(mockDataStore, Mockito.times(1)).saveCredentialOffer(any());
         assertThat(response.getStatus(), is(500));
+    }
+
+    @Test
+    @DisplayName("Should return 400 when a walletSubjectID is not a valid value")
+    void testItValidatesInputParam_walletSubjectID() {
+        final Response response =
+                EXT.target("/credential_offer")
+                        .queryParam("walletSubjectId", "123")
+                        .queryParam("documentId", DOCUMENT_ID)
+                        .queryParam("credentialType", CREDENTIAL_TYPE)
+                        .request()
+                        .get();
+        assertThat(response.getStatus(), is(400));
+    }
+
+    @Test
+    @DisplayName("Should return 400 when a documentId is not a valid value")
+    void testItValidatesInputParam_documentId() {
+        final Response response =
+                EXT.target("/credential_offer")
+                        .queryParam("walletSubjectId", WALLET_SUBJECT_ID)
+                        .queryParam("documentId", "&&^")
+                        .queryParam("credentialType", CREDENTIAL_TYPE)
+                        .request()
+                        .get();
+        assertThat(response.getStatus(), is(400));
+    }
+
+    @Test
+    @DisplayName("Should return 400 when a credentialType is not a valid value")
+    void testItValidatesInputParam_credentialType() {
+        final Response response =
+                EXT.target("/credential_offer")
+                        .queryParam("walletSubjectId", WALLET_SUBJECT_ID)
+                        .queryParam("documentId", DOCUMENT_ID)
+                        .queryParam("credentialType", "???")
+                        .request()
+                        .get();
+        assertThat(response.getStatus(), is(400));
     }
 
     private CredentialOffer getMockCredentialOffer() {


### PR DESCRIPTION
## Proposed changes
Validate the format of the request parameters for the get credential offer request. 

### What changed
Use jackson pattern validation to validate inputs before application code is run. 

### Why did it change
Allowing any input value makes the service vulnerable to injection attacks and others. 

### Testing
Deployed this branch and the corresponding CRI change to Dev and tested that the changes are compatible.
![Screenshot 2024-07-03 at 16 54 25](https://github.com/govuk-one-login/mobile-wallet-document-builder/assets/24165331/bc263bc6-39db-4a5a-8d54-5237eefbf8f9)

