### PR TITLE
fix(DCMAW): hash key ID in the credential offer pre-auth code

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential_offer/CredentialOfferResource.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential_offer/CredentialOfferResource.java
@@ -21,6 +21,7 @@ import uk.gov.di.mobile.wallet.cri.services.signing.SigningException;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 
 @Singleton
@@ -64,7 +65,7 @@ public class CredentialOfferResource {
         try {
             credentialOffer =
                     credentialOfferService.buildCredentialOffer(credentialOfferId, credentialType);
-        } catch (SigningException exception) {
+        } catch (SigningException | NoSuchAlgorithmException exception) {
             LOGGER.error(
                     "Failed to create credential offer for walletSubjectId {} and documentId {}",
                     walletSubjectId,

--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential_offer/CredentialOfferService.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential_offer/CredentialOfferService.java
@@ -7,6 +7,7 @@ import uk.gov.di.mobile.wallet.cri.services.ConfigurationService;
 import uk.gov.di.mobile.wallet.cri.services.signing.KmsService;
 import uk.gov.di.mobile.wallet.cri.services.signing.SigningException;
 
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,7 +24,7 @@ public class CredentialOfferService {
     }
 
     public CredentialOffer buildCredentialOffer(String credentialIdentifier, String credentialType)
-            throws SigningException {
+            throws SigningException, NoSuchAlgorithmException {
         SignedJWT preAuthorizedCode =
                 new PreAuthorizedCodeBuilder(configurationService, kmsService)
                         .buildPreAuthorizedCode(credentialIdentifier);

--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential_offer/PreAuthorizedCodeBuilder.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential_offer/PreAuthorizedCodeBuilder.java
@@ -13,9 +13,11 @@ import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SignResponse;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import uk.gov.di.mobile.wallet.cri.services.ConfigurationService;
+import uk.gov.di.mobile.wallet.cri.services.signing.KeyHelper;
 import uk.gov.di.mobile.wallet.cri.services.signing.KeyProvider;
 import uk.gov.di.mobile.wallet.cri.services.signing.SigningException;
 
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -33,9 +35,12 @@ public class PreAuthorizedCodeBuilder {
         this.keyProvider = keyProvider;
     }
 
-    public SignedJWT buildPreAuthorizedCode(String credentialIdentifier) throws SigningException {
+    public SignedJWT buildPreAuthorizedCode(String credentialIdentifier)
+            throws SigningException, NoSuchAlgorithmException {
         String keyId = keyProvider.getKeyId(configurationService.getSigningKeyAlias());
-        var encodedHeader = getEncodedHeader(keyId);
+        String hashedKeyId =
+                KeyHelper.hashKeyId(keyId, configurationService.getKeyIdHashingAlgorithm());
+        var encodedHeader = getEncodedHeader(hashedKeyId);
         var encodedClaims = getEncodedClaims(credentialIdentifier);
         var message = encodedHeader + "." + encodedClaims;
         var signRequest =

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential_offer/CredentialOfferResourceTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential_offer/CredentialOfferResourceTest.java
@@ -28,6 +28,7 @@ import uk.gov.di.mobile.wallet.cri.services.data_storage.DynamoDbService;
 import uk.gov.di.mobile.wallet.cri.services.signing.KmsService;
 import uk.gov.di.mobile.wallet.cri.services.signing.SigningException;
 
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -64,7 +65,7 @@ class CredentialOfferResourceTest {
     @Test
     @DisplayName("Should return 200 and the URL encoded credential offer")
     void testItReturns200AndUrlEncodedCredentialOffer()
-            throws JOSEException, DataStoreException, SigningException {
+            throws JOSEException, DataStoreException, SigningException, NoSuchAlgorithmException {
         SignResponse signResponse = getMockedSignResponse();
         CredentialOffer mockCredentialOffer = getMockCredentialOffer();
 

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential_offer/CredentialOfferServiceTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential_offer/CredentialOfferServiceTest.java
@@ -20,6 +20,8 @@ import uk.gov.di.mobile.wallet.cri.services.ConfigurationService;
 import uk.gov.di.mobile.wallet.cri.services.signing.KmsService;
 import uk.gov.di.mobile.wallet.cri.services.signing.SigningException;
 
+import java.security.NoSuchAlgorithmException;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.startsWith;
@@ -43,7 +45,8 @@ class CredentialOfferServiceTest {
 
     @Test
     @DisplayName("Should build and return a credential offer")
-    void testItReturnsCredentialOffer() throws SigningException, JOSEException {
+    void testItReturnsCredentialOffer()
+            throws SigningException, JOSEException, NoSuchAlgorithmException {
         SignResponse signResponse = getMockedSignResponse();
         when(kmsService.sign(any(SignRequest.class))).thenReturn(signResponse);
         when(kmsService.getKeyId(any(String.class))).thenReturn(KEY_ID);
@@ -61,7 +64,8 @@ class CredentialOfferServiceTest {
                         .getGrants()
                         .get("urn:ietf:params:oauth:grant-type:pre-authorized_code")
                         .get("pre-authorized_code"),
-                startsWith("eyJraWQiOiJmZjI3NWI5Mi0wZGVm"));
+                startsWith(
+                        "eyJraWQiOiI3OGZhMTMxZDY3N2MxYWMwZjE3MmM1M2I0N2FjMTY5YTk1YWQwZDkyYzM4YmQ3OTRhNzBkYTU5MDMyMDU4Mjc0IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ."));
     }
 
     private SignResponse getMockedSignResponse() throws JOSEException {

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential_offer/PreAuthorizedCodeBuilderTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential_offer/PreAuthorizedCodeBuilderTest.java
@@ -22,6 +22,7 @@ import uk.gov.di.mobile.wallet.cri.services.ConfigurationService;
 import uk.gov.di.mobile.wallet.cri.services.signing.KmsService;
 import uk.gov.di.mobile.wallet.cri.services.signing.SigningException;
 
+import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -53,7 +54,8 @@ class PreAuthorizedCodeBuilderTest {
     @Test
     @DisplayName(
             "Should build the pre-authorized code with the correct claims and sign it with KMS")
-    void testItReturnsSignedJwt() throws SigningException, ParseException, JOSEException {
+    void testItReturnsSignedJwt()
+            throws SigningException, ParseException, JOSEException, NoSuchAlgorithmException {
         SignResponse signResponse = getMockedSignResponse();
         when(kmsService.sign(any(SignRequest.class))).thenReturn(signResponse);
         when(kmsService.getKeyId(any(String.class))).thenReturn(KEY_ID);
@@ -82,7 +84,7 @@ class PreAuthorizedCodeBuilderTest {
                 equalTo(true));
         assertThat(
                 preAuthorizedCode.getHeader().getKeyID(),
-                equalTo("ff275b92-0def-4dfc-b0f6-87c96b26c6c7"));
+                equalTo("78fa131d677c1ac0f172c53b47ac169a95ad0d92c38bd794a70da59032058274"));
         assertThat(preAuthorizedCode.getHeader().getAlgorithm(), equalTo(JWSAlgorithm.ES256));
         assertThat(preAuthorizedCode.getHeader().getType(), equalTo(JOSEObjectType.JWT));
     }
@@ -90,6 +92,7 @@ class PreAuthorizedCodeBuilderTest {
     @Test
     @DisplayName("Should throw a SigningException when KMS throws an exception")
     void testItThrowsSigningException() {
+        when(kmsService.getKeyId(any(String.class))).thenReturn(KEY_ID);
         when(kmsService.sign(any(SignRequest.class))).thenThrow(DisabledException.class);
 
         SigningException exception =


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->

### What changed
- Hash the key ID before assigning it to the kid header claim of the pre-authorized code

https://github.com/user-attachments/assets/f32c7c0a-67c6-466f-b33b-0cd4bd825104

![Screenshot 2024-07-17 at 11 01 54](https://github.com/user-attachments/assets/9b086c2c-dc90-427d-9f70-5b8644b26a75)

![Screenshot 2024-07-17 at 11 06 11](https://github.com/user-attachments/assets/e8d71b38-4cb1-4aee-b5c2-6b44dd80ef41)


### Why did it change
- Key ID must be hashed so that it matches the key ID in the DID document

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

No ticket raised for this fix

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [x] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other consideration if needed -->