### PR TITLE
fix: correct the client-id and aud claims in pre-auth-code

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -29,6 +29,10 @@ Parameters:
       The port on which the container is running
     Type: Number
     Default: 8080
+  DocumentBuilderStackName:
+    Description: The cloudformation stack name of the document builder
+    Type: String
+    Default: "wallet-doc-builder-fe"
 
 Conditions:
   StackNameIsWalletCredIssuerBE: !Equals [ !Ref "AWS::StackName", wallet-cred-issuer-be ]
@@ -417,6 +421,8 @@ Resources:
                 - ${SelfUrl}
                 - SelfUrl:
                     !FindInMap [ EnvironmentVariables, !Ref Environment, SelfUrl ]
+            - Name: OIDC_CLIENT_ID
+              Value: !Sub "{{resolve:ssm:/${DocumentBuilderStackName}/Config/OIDC/Client/Id}}"
             - Name: CREDENTIAL_STORE_URL
               Value: !Sub 
                       - "https://${CredentialStoreUrl}"

--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential_offer/PreAuthorizedCodeBuilder.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential_offer/PreAuthorizedCodeBuilder.java
@@ -72,7 +72,7 @@ public class PreAuthorizedCodeBuilder {
 
         var claimsBuilder =
                 new JWTClaimsSet.Builder()
-                        .audience(configurationService.getAudience())
+                        .audience(configurationService.getOneLoginAuthServerUrl())
                         .issuer(configurationService.getIssuer())
                         .issueTime(Date.from(now))
                         .expirationTime(

--- a/src/main/java/uk/gov/di/mobile/wallet/cri/services/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/services/ConfigurationService.java
@@ -41,15 +41,11 @@ public class ConfigurationService extends Configuration {
     }
 
     public String getClientId() {
-        return "EXAMPLE_CRI";
+        return System.getenv().getOrDefault("OIDC_CLIENT_ID", "TEST_CLIENT_ID");
     }
 
     public String getIssuer() {
         return "urn:fdc:gov:uk:example-credential-issuer";
-    }
-
-    public String getAudience() {
-        return "urn:fdc:gov:uk:wallet";
     }
 
     public String getLocalstackEndpoint() {

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential_offer/PreAuthorizedCodeBuilderTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential_offer/PreAuthorizedCodeBuilderTest.java
@@ -66,9 +66,10 @@ class PreAuthorizedCodeBuilderTest {
 
         assertThat(
                 preAuthorizedCode.getJWTClaimsSet().getAudience(),
-                equalTo(singletonList("urn:fdc:gov:uk:wallet")));
+                equalTo(singletonList("http://localhost:8888")));
         assertThat(
-                preAuthorizedCode.getJWTClaimsSet().getClaim("clientId"), equalTo("EXAMPLE_CRI"));
+                preAuthorizedCode.getJWTClaimsSet().getClaim("clientId"),
+                equalTo("TEST_CLIENT_ID"));
         assertThat(
                 preAuthorizedCode.getJWTClaimsSet().getIssuer(),
                 equalTo("urn:fdc:gov:uk:example-credential-issuer"));

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/services/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/services/ConfigurationServiceTest.java
@@ -133,17 +133,12 @@ class ConfigurationServiceTest {
 
     @Test
     void shouldGetClientIdValue() {
-        assertEquals("EXAMPLE_CRI", configurationService.getClientId());
+        assertEquals("TEST_CLIENT_ID", configurationService.getClientId());
     }
 
     @Test
     void shouldGetIssuerValue() {
         assertEquals("urn:fdc:gov:uk:example-credential-issuer", configurationService.getIssuer());
-    }
-
-    @Test
-    void shouldGetAudienceValue() {
-        assertEquals("urn:fdc:gov:uk:wallet", configurationService.getAudience());
     }
 
     @Test


### PR DESCRIPTION
### What changed
- Client ID in the pre-auth-code needs to be the OIDC client ID so it is now pulling that from AWS SSM
- audience claim in the pre-auth-code needs to be the domain of STS (auth provider)

### Why did it change
Integration with SYS in staging is not working

![Screenshot 2024-07-30 at 18 39 11](https://github.com/user-attachments/assets/89c4499f-d6ad-4312-a6f3-2e0be0de3b3f)
![Screenshot 2024-07-30 at 18 37 54](https://github.com/user-attachments/assets/ff5398c3-1883-4deb-a61d-6c6369da7148)
