### PR TITLE
fix: add use claim to jwks

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/services/signing/KmsService.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/services/signing/KmsService.java
@@ -1,6 +1,7 @@
 package uk.gov.di.mobile.wallet.cri.services.signing;
 
 import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.KeyUse;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.openssl.PEMException;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
@@ -113,6 +114,7 @@ public class KmsService implements KeyProvider {
         return new ECKey.Builder(P_256, (ECPublicKey) publicKey)
                 .keyID(hashedKeyId)
                 .algorithm(ES256)
+                .keyUse(KeyUse.SIGNATURE)
                 .build();
     }
 

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/jwks/JwksResourceTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/jwks/JwksResourceTest.java
@@ -56,7 +56,7 @@ class JwksResourceTest {
             throws ParseException, KeyNotActiveException, PEMException, NoSuchAlgorithmException {
         JWK publicKey =
                 JWK.parse(
-                        "{\"kty\":\"EC\",\"crv\":\"P-256\",\"kid\":\"d7cb2ed24d8f70433e293ebc270bf1de77fcfab02a7f631da396b70e9b3aa8d7\",\"x\":\"sSdmBkED2EfjTdX-K2_cT6CfBwXQFt-DJ6v8-6tr_n8\",\"y\":\"WTXmQdqLwrmHN5tiFsTFUtNAvDYhhTQB4zyfteCrWIE\",\"alg\":\"ES256\"}");
+                        "{\"kty\":\"EC\",\"crv\":\"P-256\",\"kid\":\"d7cb2ed24d8f70433e293ebc270bf1de77fcfab02a7f631da396b70e9b3aa8d7\",\"x\":\"sSdmBkED2EfjTdX-K2_cT6CfBwXQFt-DJ6v8-6tr_n8\",\"y\":\"WTXmQdqLwrmHN5tiFsTFUtNAvDYhhTQB4zyfteCrWIE\",\"alg\":\"ES256\",\"use\":\"sig\"}");
         var expectedJWKSet = new JWKSet(List.of(publicKey));
         when(jwksService.generateJwks()).thenReturn(expectedJWKSet);
 


### PR DESCRIPTION
## Proposed changes
Add `"use": "sig"` claim to the signing key JWK so it's clear this key is to be used for signing. 

### Why did it change
STS consumer of the JWKS API filters for keys with signing use type.

![Screenshot 2024-07-31 at 09 50 25](https://github.com/user-attachments/assets/7a0e6fe6-4cd4-4745-95a8-0c9cd3a1514f)
