### PR TITLE
DCMAW-10576: change Document Builder port to be 8001

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/services/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/services/ConfigurationService.java
@@ -25,11 +25,11 @@ public class ConfigurationService extends Configuration {
     }
 
     public String getOneLoginAuthServerUrl() {
-        return System.getenv().getOrDefault("ONE_LOGIN_AUTH_SERVER_URL", "http://localhost:8888");
+        return System.getenv().getOrDefault("ONE_LOGIN_AUTH_SERVER_URL", "http://localhost:8001");
     }
 
     public String getCredentialStoreUrl() {
-        return System.getenv().getOrDefault("CREDENTIAL_STORE_URL", "http://localhost:8888");
+        return System.getenv().getOrDefault("CREDENTIAL_STORE_URL", "http://localhost:8001");
     }
 
     public String getWalletDeepLinkUrl() {

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/services/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/services/ConfigurationServiceTest.java
@@ -83,7 +83,7 @@ class ConfigurationServiceTest {
 
     @Test
     void shouldGetOneLoginAuthServerUrlDefaultValueWhenEnvVarUnset() {
-        assertEquals("http://localhost:8888", configurationService.getOneLoginAuthServerUrl());
+        assertEquals("http://localhost:8001", configurationService.getOneLoginAuthServerUrl());
     }
 
     @Test
@@ -97,7 +97,7 @@ class ConfigurationServiceTest {
 
     @Test
     void shouldGetCredentialStoreUrlDefaultValueWhenEnvVarUnset() {
-        assertEquals("http://localhost:8888", configurationService.getCredentialStoreUrl());
+        assertEquals("http://localhost:8001", configurationService.getCredentialStoreUrl());
     }
 
     @Test


### PR DESCRIPTION
Related PR: https://github.com/govuk-one-login/mobile-wallet-document-builder/pull/117

## Proposed changes
### What changed
- Update Document Builder (i.e. `ONE_LOGIN_AUTH_SERVER_URL` and `CREDENTIAL_STORE_URL`) default port to be `8001` instead of `8888` 

### Why did it change
The Document Builder will use port `8001` going forward as Docker Desktop started using port `8888` after a recent update and any containers binding to that port fail.

### Issue tracking
- [DCMAW-10576](https://govukverify.atlassian.net/browse/DCMAW-10576)

## Checklists
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

[DCMAW-10576]: https://govukverify.atlassian.net/browse/DCMAW-10576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ