### PR TITLE
refactor: rename getCredentialTtlInSecs to getCredentialTtlInDays

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential/CredentialBuilder.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential/CredentialBuilder.java
@@ -85,7 +85,7 @@ public class CredentialBuilder {
                         .expirationTime(
                                 Date.from(
                                         now.plus(
-                                                configurationService.getCredentialTtlInSecs(),
+                                                configurationService.getCredentialTtlInDays(),
                                                 ChronoUnit.DAYS)))
                         .subject(proofJwtDidKey)
                         .claim("vc", documentDetails)

--- a/src/main/java/uk/gov/di/mobile/wallet/cri/services/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/services/ConfigurationService.java
@@ -53,7 +53,7 @@ public class ConfigurationService extends Configuration {
         return 300;
     }
 
-    public long getCredentialTtlInSecs() {
+    public long getCredentialTtlInDays() {
         return 365;
     }
 

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialBuilderTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialBuilderTest.java
@@ -62,7 +62,7 @@ class CredentialBuilderTest {
         credentialBuilder = new CredentialBuilder(configurationService, kmsService);
         when(configurationService.getSigningKeyAlias()).thenReturn("test-signing-key-alias");
         when(configurationService.getSelfUrl()).thenReturn(TEST_EXAMPLE_CREDENTIAL_ISSUER);
-        when(configurationService.getCredentialTtlInSecs()).thenReturn(300L);
+        when(configurationService.getCredentialTtlInDays()).thenReturn(300L);
         documentDetails =
                 new ObjectMapper()
                         .readTree(

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/services/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/services/ConfigurationServiceTest.java
@@ -152,7 +152,7 @@ class ConfigurationServiceTest {
 
     @Test
     void shouldGetCredentialTtlValue() {
-        assertEquals(365, configurationService.getCredentialTtlInSecs());
+        assertEquals(365, configurationService.getCredentialTtlInDays());
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes
### What changed
The `getCredentialTtlInSecs` method has been renamed to `getCredentialTtlInDays`.

### Why did it change
Credentials are valid for 365 days and not seconds, so the method was incorrectly named.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

No ticket raised.

## Testing

## Checklist
- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
