### PR TITLE
DCMAW-11267: update gradle and docker dependencies with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,35 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-# Set update schedule for GitHub Actions
 version: 2
 updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "06:00"
+    target-branch: main
+    labels:
+      - dependabot
+      - dependencies
+    commit-message:
+      prefix: chore
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "06:00"
+    target-branch: main
+    labels:
+      - dependabot
+      - dependencies
+    commit-message:
+      prefix: chore
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"
+      interval: daily
+      time: "06:00"
+    target-branch: main
+    labels:
+      - dependabot
+      - dependencies
+    commit-message:
+      prefix: chore


### PR DESCRIPTION
## Proposed changes
### What changed
Add `gradle` and `docker` to `dependabot.yaml`.

### Why did it change
So that PRs are automatically raised daily to update `gradle` and `docker` dependencies.

### Issue tracking
- [DCMAW-11267](https://govukverify.atlassian.net/browse/DCMAW-11267)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-11267]: https://govukverify.atlassian.net/browse/DCMAW-11267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ