### PR TITLE
DCMAW-11002: rename class methods and add comments

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential/CredentialBuilder.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential/CredentialBuilder.java
@@ -51,10 +51,10 @@ public class CredentialBuilder<T extends CredentialSubject> {
     }
 
     // VC MD v1.1 - to be removed once Wallet switches over to VC MD v2.0
-    public Credential buildCredentialV1(String proofJwtDidKey, VCClaim vcClaim)
+    public Credential buildV1Credential(String proofJwtDidKey, VCClaim vcClaim)
             throws SigningException, NoSuchAlgorithmException {
         String keyId = keyProvider.getKeyId(configurationService.getSigningKeyAlias());
-        var encodedHeader = getEncodedHeaderV1(keyId);
+        var encodedHeader = getV1EncodedHeader(keyId);
         var encodedClaims = getV1EncodedClaims(proofJwtDidKey, vcClaim);
         var message = encodedHeader + "." + encodedClaims;
 
@@ -80,14 +80,14 @@ public class CredentialBuilder<T extends CredentialSubject> {
         }
     }
 
-    public Credential buildCredentialV2(
+    public Credential buildV2Credential(
             T credentialSubject, CredentialType credentialType, String validUntil)
             throws SigningException, NoSuchAlgorithmException {
         // keyId is the hashed key ID. This value must be appended to the string
         // "did:web:example-credential-issuer.mobile.build.account.gov.uk#" in this ticket:
         // https://govukverify.atlassian.net/browse/DCMAW-11424
         String keyId = keyProvider.getKeyId(configurationService.getSigningKeyAlias());
-        var encodedHeader = getEncodedHeaderV2(keyId);
+        var encodedHeader = getV2EncodedHeader(keyId);
         var encodedClaims = getV2EncodedClaims(credentialSubject, credentialType, validUntil);
         var message = encodedHeader + "." + encodedClaims;
 
@@ -174,7 +174,7 @@ public class CredentialBuilder<T extends CredentialSubject> {
     }
 
     // VC MD v1.1 - to be removed once Wallet switches over to VC MD v2.0
-    private Base64URL getEncodedHeaderV1(String keyId) throws NoSuchAlgorithmException {
+    private Base64URL getV1EncodedHeader(String keyId) throws NoSuchAlgorithmException {
         String hashedKeyId = KeyHelper.hashKeyId(keyId);
         var jwsHeader =
                 new JWSHeader.Builder(SIGNING_ALGORITHM)
@@ -184,7 +184,7 @@ public class CredentialBuilder<T extends CredentialSubject> {
         return jwsHeader.toBase64URL();
     }
 
-    private Base64URL getEncodedHeaderV2(String keyId) throws NoSuchAlgorithmException {
+    private Base64URL getV2EncodedHeader(String keyId) throws NoSuchAlgorithmException {
         String hashedKeyId = KeyHelper.hashKeyId(keyId);
         var jwsHeader =
                 new JWSHeader.Builder(SIGNING_ALGORITHM)

--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential/CredentialService.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential/CredentialService.java
@@ -191,14 +191,15 @@ public class CredentialService {
         SocialSecurityCredentialSubject socialSecurityCredentialSubject =
                 CredentialSubjectMapper.buildSocialSecurityCredentialSubject(document, sub);
         if (Objects.equals(document.getVcDataModel(), "v1.1")) {
+            // Build "vc" claim required in VC DM v1.1
             VCClaim vcClaim =
                     new VCClaim(
                             vcType,
                             getSocialSecurityCredentialSubjectV1(socialSecurityCredentialSubject));
-            return credentialBuilder.buildCredentialV1(sub, vcClaim);
+            return credentialBuilder.buildV1Credential(sub, vcClaim);
         } else {
             return ((CredentialBuilder<SocialSecurityCredentialSubject>) credentialBuilder)
-                    .buildCredentialV2(
+                    .buildV2Credential(
                             socialSecurityCredentialSubject, SOCIAL_SECURITY_CREDENTIAL, null);
         }
     }
@@ -208,13 +209,14 @@ public class CredentialService {
         BasicCheckCredentialSubject basicCheckCredentialSubject =
                 CredentialSubjectMapper.buildBasicCheckCredentialSubject(document, sub);
         if (Objects.equals(document.getVcDataModel(), "v1.1")) {
+            // Build "vc" claim required in VC DM v1.1
             VCClaim vcClaim =
                     new VCClaim(
                             vcType, getBasicCheckCredentialSubjectV1(basicCheckCredentialSubject));
-            return credentialBuilder.buildCredentialV1(sub, vcClaim);
+            return credentialBuilder.buildV1Credential(sub, vcClaim);
         } else {
             return ((CredentialBuilder<BasicCheckCredentialSubject>) credentialBuilder)
-                    .buildCredentialV2(
+                    .buildV2Credential(
                             basicCheckCredentialSubject,
                             BASIC_CHECK_CREDENTIAL,
                             basicCheckCredentialSubject.getExpirationDate());
@@ -226,14 +228,15 @@ public class CredentialService {
         VeteranCardCredentialSubject veteranCardCredentialSubject =
                 CredentialSubjectMapper.buildVeteranCardCredentialSubject(document, sub);
         if (Objects.equals(document.getVcDataModel(), "v1.1")) {
+            // Build "vc" claim required in VC DM v1.1
             VCClaim vcClaim =
                     new VCClaim(
                             vcType,
                             getVeteranCardCredentialSubjectV1(veteranCardCredentialSubject));
-            return credentialBuilder.buildCredentialV1(sub, vcClaim);
+            return credentialBuilder.buildV1Credential(sub, vcClaim);
         } else {
             return ((CredentialBuilder<VeteranCardCredentialSubject>) credentialBuilder)
-                    .buildCredentialV2(
+                    .buildV2Credential(
                             veteranCardCredentialSubject,
                             DIGITAL_VETERAN_CARD,
                             veteranCardCredentialSubject.getVeteranCard().get(0).getExpiryDate());
@@ -243,6 +246,8 @@ public class CredentialService {
     // Needed for VC MD v1.1 - to be removed once Wallet switches over to VC MD v2.0
     private static @NotNull SocialSecurityCredentialSubjectV1 getSocialSecurityCredentialSubjectV1(
             SocialSecurityCredentialSubject socialSecurityCredentialSubject) {
+        // Map SocialSecurityCredentialSubject into SocialSecurityCredentialSubjectV1 (i.e. no "id"
+        // property)
         return new SocialSecurityCredentialSubjectV1(
                 socialSecurityCredentialSubject.getName(),
                 socialSecurityCredentialSubject.getSocialSecurityRecord());
@@ -251,6 +256,8 @@ public class CredentialService {
     // Needed for VC MD v1.1 - to be removed once Wallet switches over to VC MD v2.0
     private static @NotNull BasicCheckCredentialSubjectV1 getBasicCheckCredentialSubjectV1(
             BasicCheckCredentialSubject basicCheckCredentialSubject) {
+        // Map BasicCheckCredentialSubject into BasicCheckCredentialSubjectV1 (i.e. no "id"
+        // property)
         return new BasicCheckCredentialSubjectV1(
                 basicCheckCredentialSubject.getIssuanceDate(),
                 basicCheckCredentialSubject.getExpirationDate(),
@@ -263,6 +270,8 @@ public class CredentialService {
     // Needed for VC MD v1.1 - to be removed once Wallet switches over to VC MD v2.0
     private static @NotNull VeteranCardCredentialSubjectV1 getVeteranCardCredentialSubjectV1(
             VeteranCardCredentialSubject veteranCardCredentialSubject) {
+        // Map VeteranCardCredentialSubject into VeteranCardCredentialSubjectV1 (i.e. no "id"
+        // property)
         return new VeteranCardCredentialSubjectV1(
                 veteranCardCredentialSubject.getName(),
                 veteranCardCredentialSubject.getBirthDate(),

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialBuilderTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialBuilderTest.java
@@ -111,7 +111,7 @@ class CredentialBuilderTest {
         SignResponse mockSignResponse = getMockKmsSignResponse();
         when(kmsService.sign(any(SignRequest.class))).thenReturn(mockSignResponse);
 
-        credentialBuilderSocialSecurity.buildCredentialV2(
+        credentialBuilderSocialSecurity.buildV2Credential(
                 socialSecurityCredentialSubject, CredentialType.SOCIAL_SECURITY_CREDENTIAL, null);
 
         verify(kmsService).sign(signRequestArgumentCaptor.capture());
@@ -131,7 +131,7 @@ class CredentialBuilderTest {
                 assertThrows(
                         SigningException.class,
                         () ->
-                                credentialBuilderSocialSecurity.buildCredentialV2(
+                                credentialBuilderSocialSecurity.buildV2Credential(
                                         socialSecurityCredentialSubject,
                                         CredentialType.SOCIAL_SECURITY_CREDENTIAL,
                                         null));
@@ -146,7 +146,7 @@ class CredentialBuilderTest {
         when(kmsService.sign(any(SignRequest.class))).thenReturn(mockSignResponse);
 
         Credential credential =
-                credentialBuilderSocialSecurity.buildCredentialV1(
+                credentialBuilderSocialSecurity.buildV1Credential(
                         DID_KEY, new VCClaim("SocialSecurityCredential", documentV1));
 
         SignedJWT token = SignedJWT.parse(credential.getCredential());
@@ -179,7 +179,7 @@ class CredentialBuilderTest {
         when(kmsService.sign(any(SignRequest.class))).thenReturn(mockSignResponse);
 
         Credential credential =
-                credentialBuilderSocialSecurity.buildCredentialV2(
+                credentialBuilderSocialSecurity.buildV2Credential(
                         socialSecurityCredentialSubject,
                         CredentialType.SOCIAL_SECURITY_CREDENTIAL,
                         null);
@@ -230,7 +230,7 @@ class CredentialBuilderTest {
         when(kmsService.sign(any(SignRequest.class))).thenReturn(mockSignResponse);
 
         Credential credential =
-                credentialBuilderBasicCheck.buildCredentialV2(
+                credentialBuilderBasicCheck.buildV2Credential(
                         basicCheckCredentialSubject,
                         CredentialType.BASIC_CHECK_CREDENTIAL,
                         "2025-07-11");
@@ -281,7 +281,7 @@ class CredentialBuilderTest {
         when(kmsService.sign(any(SignRequest.class))).thenReturn(mockSignResponse);
 
         Credential credential =
-                credentialBuilderVeteranCard.buildCredentialV2(
+                credentialBuilderVeteranCard.buildV2Credential(
                         veteranCardCredentialSubject,
                         CredentialType.DIGITAL_VETERAN_CARD,
                         "2000-07-11");

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialServiceTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialServiceTest.java
@@ -243,12 +243,12 @@ class CredentialServiceTest {
         when(mockResponse.getStatus()).thenReturn(200);
         when(mockResponse.readEntity(Document.class))
                 .thenReturn(getMockSocialSecurityDocument(DOCUMENT_ID, "v2.0", null));
-        when(mockCredentialBuilder.buildCredentialV2(any(), any(), any())).thenReturn(any());
+        when(mockCredentialBuilder.buildV2Credential(any(), any(), any())).thenReturn(any());
 
         credentialService.getCredential(mockAccessToken, mockProofJwt);
 
         verify((CredentialBuilder<SocialSecurityCredentialSubject>) mockCredentialBuilder, times(1))
-                .buildCredentialV2(
+                .buildV2Credential(
                         any(SocialSecurityCredentialSubject.class),
                         eq(CredentialType.SOCIAL_SECURITY_CREDENTIAL),
                         eq(null));
@@ -272,12 +272,12 @@ class CredentialServiceTest {
         when(mockResponse.getStatus()).thenReturn(200);
         when(mockResponse.readEntity(Document.class))
                 .thenReturn(getMockBasicCheckDocument(DOCUMENT_ID));
-        when(mockCredentialBuilder.buildCredentialV2(any(), any(), anyString())).thenReturn(any());
+        when(mockCredentialBuilder.buildV2Credential(any(), any(), anyString())).thenReturn(any());
 
         credentialService.getCredential(mockAccessToken, mockProofJwt);
 
         verify((CredentialBuilder<BasicCheckCredentialSubject>) mockCredentialBuilder, times(1))
-                .buildCredentialV2(
+                .buildV2Credential(
                         any(BasicCheckCredentialSubject.class),
                         eq(CredentialType.BASIC_CHECK_CREDENTIAL),
                         eq("2025-07-11"));
@@ -301,12 +301,12 @@ class CredentialServiceTest {
         when(mockResponse.getStatus()).thenReturn(200);
         when(mockResponse.readEntity(Document.class))
                 .thenReturn(getMockVeteranCardDocument(DOCUMENT_ID));
-        when(mockCredentialBuilder.buildCredentialV2(any(), any(), anyString())).thenReturn(any());
+        when(mockCredentialBuilder.buildV2Credential(any(), any(), anyString())).thenReturn(any());
 
         credentialService.getCredential(mockAccessToken, mockProofJwt);
 
         verify((CredentialBuilder<VeteranCardCredentialSubject>) mockCredentialBuilder, times(1))
-                .buildCredentialV2(
+                .buildV2Credential(
                         any(VeteranCardCredentialSubject.class),
                         eq(CredentialType.DIGITAL_VETERAN_CARD),
                         eq("2000-07-11"));
@@ -330,11 +330,11 @@ class CredentialServiceTest {
         when(mockResponse.getStatus()).thenReturn(200);
         when(mockResponse.readEntity(Document.class))
                 .thenReturn(getMockSocialSecurityDocument(DOCUMENT_ID, "v1.1", null));
-        when(mockCredentialBuilder.buildCredentialV1(anyString(), any())).thenReturn(any());
+        when(mockCredentialBuilder.buildV1Credential(anyString(), any())).thenReturn(any());
 
         credentialService.getCredential(mockAccessToken, mockProofJwt);
 
-        verify(mockCredentialBuilder, times(1)).buildCredentialV1(eq(DID_KEY), any(VCClaim.class));
+        verify(mockCredentialBuilder, times(1)).buildV1Credential(eq(DID_KEY), any(VCClaim.class));
     }
 
     @Test
@@ -383,7 +383,7 @@ class CredentialServiceTest {
                 SignedJWT.parse(
                         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
         Credential mockCredential = new Credential(mockCredentialJwt);
-        when(mockCredentialBuilder.buildCredentialV2(any(), any(), any()))
+        when(mockCredentialBuilder.buildV2Credential(any(), any(), any()))
                 .thenReturn(mockCredential);
 
         Credential credentialServiceReturnValue =
@@ -395,7 +395,7 @@ class CredentialServiceTest {
         verify(mockDynamoDbService, times(1)).getCredentialOffer(CREDENTIAL_IDENTIFIER);
         verify(mockDynamoDbService, times(1)).deleteCredentialOffer(CREDENTIAL_IDENTIFIER);
         verify((CredentialBuilder<SocialSecurityCredentialSubject>) mockCredentialBuilder, times(1))
-                .buildCredentialV2(
+                .buildV2Credential(
                         any(SocialSecurityCredentialSubject.class),
                         eq(CredentialType.SOCIAL_SECURITY_CREDENTIAL),
                         eq(null));


### PR DESCRIPTION
## Proposed changes
### What changed
- Rename methods in the CredentialBuilder class so that their name corresponds to the implementation (V1 vs V2)
- Add comment to explain implementation decision
- Add comment to highlight change required as part of DCMAW-11424 

### Why did it change
<!-- Describe the reason these changes were made -->

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-11002](https://govukverify.atlassian.net/browse/DCMAW-11002)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/pull/98

[DCMAW-11002]: https://govukverify.atlassian.net/browse/DCMAW-11002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ