### PR TITLE
BAU: rename method parameter for clarity

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential_offer/PreAuthorizedCodeBuilder.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential_offer/PreAuthorizedCodeBuilder.java
@@ -67,7 +67,7 @@ public class PreAuthorizedCodeBuilder {
                 .toString();
     }
 
-    private Base64URL getEncodedClaims(String walletSubjectId) {
+    private Base64URL getEncodedClaims(String credentialIdentifier) {
         Instant now = Instant.now();
 
         var claimsBuilder =
@@ -82,7 +82,7 @@ public class PreAuthorizedCodeBuilder {
                                                         .getPreAuthorizedCodeTtlInSecs(),
                                                 ChronoUnit.SECONDS)))
                         .claim("clientId", configurationService.getClientId())
-                        .claim("credential_identifiers", new String[] {walletSubjectId});
+                        .claim("credential_identifiers", new String[] {credentialIdentifier});
 
         return Base64URL.encode(claimsBuilder.build().toString());
     }


### PR DESCRIPTION
## Proposed changes
### What changed
- Rename `getEncodedClaims` parameter `walletSubjectId` to `credentialIdentifier`

### Why did it change
- Renamed for clarity: the argument passed to this function is a credential identifier and not the Wallet Subject ID

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
