### PR TITLE
DCMAW-11036: remove obsolete credentials_endpoint metadata property 

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/metadata/Metadata.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/metadata/Metadata.java
@@ -7,16 +7,11 @@ public class Metadata {
     public Metadata(
             String credentialIssuer,
             String authorizationServers,
-            String credentialsEndpoint,
             String credentialEndpoint,
             String notificationEndpoint,
             Object credentialConfigurationsSupported) {
         this.credentialIssuer = credentialIssuer;
         this.authorizationServers = new String[] {authorizationServers};
-        // TO DO: Remove credentials_endpoint once SDK has been updated:
-        // https://govukverify.atlassian.net/browse/DCMAW-11040
-        // https://govukverify.atlassian.net/browse/DCMAW-11043
-        this.credentialsEndpoint = credentialsEndpoint;
         this.credentialEndpoint = credentialEndpoint;
         this.notificationEndpoint = notificationEndpoint;
         this.credentialConfigurationsSupported = credentialConfigurationsSupported;
@@ -24,7 +19,6 @@ public class Metadata {
 
     String credentialIssuer; // NOSONAR
     String[] authorizationServers; // NOSONAR
-    String credentialsEndpoint; // NOSONAR
     String credentialEndpoint; // NOSONAR
     String notificationEndpoint; // NOSONAR
     Object credentialConfigurationsSupported; // NOSONAR
@@ -37,11 +31,6 @@ public class Metadata {
     @JsonProperty("authorization_servers")
     public String[] getAuthorizationServers() {
         return authorizationServers;
-    }
-
-    @JsonProperty("credentials_endpoint")
-    public String getCredentialsEndpoint() {
-        return credentialsEndpoint;
     }
 
     @JsonProperty("credential_endpoint")

--- a/src/main/java/uk/gov/di/mobile/wallet/cri/metadata/MetadataBuilder.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/metadata/MetadataBuilder.java
@@ -10,7 +10,6 @@ public class MetadataBuilder {
 
     String credentialIssuer;
     String authorizationServers;
-    String credentialsEndpoint;
     String credentialEndpoint;
     String notificationEndpoint;
     Object credentialConfigurationsSupported;
@@ -30,15 +29,6 @@ public class MetadataBuilder {
             throw new IllegalArgumentException("authorizationServers must not be null");
         }
         this.authorizationServers = authorizationServers;
-        return this;
-    }
-
-    public MetadataBuilder setCredentialsEndpoint(String credentialsEndpoint)
-            throws IllegalArgumentException {
-        if (credentialsEndpoint == null) {
-            throw new IllegalArgumentException("credentialsEndpoint must not be null");
-        }
-        this.credentialsEndpoint = credentialsEndpoint;
         return this;
     }
 
@@ -77,7 +67,6 @@ public class MetadataBuilder {
         return new Metadata(
                 credentialIssuer,
                 authorizationServers,
-                credentialsEndpoint,
                 credentialEndpoint,
                 notificationEndpoint,
                 credentialConfigurationsSupported);

--- a/src/main/java/uk/gov/di/mobile/wallet/cri/metadata/MetadataResource.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/metadata/MetadataResource.java
@@ -34,7 +34,6 @@ public class MetadataResource {
             Metadata metadata =
                     metadataBuilder
                             .setCredentialIssuer(selfUrl)
-                            .setCredentialsEndpoint(selfUrl + CREDENTIAL_ENDPOINT)
                             .setCredentialEndpoint(selfUrl + CREDENTIAL_ENDPOINT)
                             .setAuthorizationServers(
                                     configurationService.getOneLoginAuthServerUrl())

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/metadata/MetadataBuilderTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/metadata/MetadataBuilderTest.java
@@ -33,7 +33,6 @@ class MetadataBuilderTest {
         Metadata metadata =
                 metadataBuilder
                         .setCredentialIssuer("https://test-credential-issuer.gov.uk")
-                        .setCredentialsEndpoint("https://test-credential-issuer.gov.uk/credential")
                         .setCredentialEndpoint("https://test-credential-issuer.gov.uk/credential")
                         .setAuthorizationServers(
                                 "https://test-authorization-server.gov.uk/auth-server")
@@ -47,8 +46,6 @@ class MetadataBuilderTest {
         assertArrayEquals(
                 new String[] {"https://test-authorization-server.gov.uk/auth-server"},
                 metadata.authorizationServers);
-        assertEquals(
-                "https://test-credential-issuer.gov.uk/credential", metadata.credentialsEndpoint);
         assertEquals(
                 "https://test-credential-issuer.gov.uk/credential", metadata.credentialEndpoint);
         assertEquals(
@@ -96,18 +93,6 @@ class MetadataBuilderTest {
                         IllegalArgumentException.class,
                         () -> metadataBuilder.setCredentialConfigurationsSupported(null));
         Assertions.assertEquals("fileName must not be null", exceptionThrown.getMessage());
-    }
-
-    @Test
-    @DisplayName(
-            "Should throw IllegalArgumentException when setCredentialsEndpoint is called with null")
-    void Should_ThrowIllegalArgumentException_When_ACredentialsEndpointIsNull() {
-        IllegalArgumentException exceptionThrown =
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () -> metadataBuilder.setCredentialsEndpoint(null));
-        Assertions.assertEquals(
-                "credentialsEndpoint must not be null", exceptionThrown.getMessage());
     }
 
     @Test

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/metadata/MetadataResourceTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/metadata/MetadataResourceTest.java
@@ -74,7 +74,6 @@ class MetadataResourceTest {
                 "https://test-credential-issuer.gov.uk",
                 "https://test-authorization-server.gov.uk",
                 "https://test-credential-issuer.gov.uk/credential",
-                "https://test-credential-issuer.gov.uk/credential",
                 "https://test-credential-issuer.gov.uk/notification",
                 credentialConfigurationsSupported);
     }


### PR DESCRIPTION
## Proposed changes
### What changed
- Remove obsolete `credentials_endpoint` from the Example CRI metadata.

### Why did it change
- This property has been replaced with `credential_endpoint`, which is the correct one. All dependencies have been updated to use the correct property so `credentials_endpoint` is no longer needed.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-11036](https://govukverify.atlassian.net/browse/DCMAW-11036)

## Testing

Tested locally.

<img width="635" alt="Screenshot 2025-03-21 at 16 05 21" src="https://github.com/user-attachments/assets/80ce7fec-3448-4308-a100-df51fbcd7c77" />

## Checklist
- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-11036]: https://govukverify.atlassian.net/browse/DCMAW-11036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ