### PR TITLE
BAU: fix code smells

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/notification/NotificationService.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/notification/NotificationService.java
@@ -53,7 +53,7 @@ public class NotificationService {
                 .info(
                         "Notification received - notification_id: {}, event: {}, event_description: {}",
                         notificationRequestBody.getNotificationId(),
-                        notificationRequestBody.getEvent().toString(),
+                        notificationRequestBody.getEvent(),
                         notificationRequestBody.getEventDescription());
     }
 

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/notification/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/notification/NotificationServiceTest.java
@@ -147,7 +147,7 @@ class NotificationServiceTest {
                 .info(
                         "Notification received - notification_id: {}, event: {}, event_description: {}",
                         "77368ca6-877b-4208-a397-99f1df890400",
-                        "credential_accepted",
+                        EventType.credential_accepted,
                         "Credential stored");
         verify(mockAccessTokenService, times(1)).verifyAccessToken(accessToken);
         verify(mockDynamoDbService, times(1)).getCredentialOffer(CREDENTIAL_IDENTIFIER);


### PR DESCRIPTION
## Proposed changes
### What changed
Remove call to `toString()` when logging the notification event.

### Why did it change
To fix two code smells in SonarQube.

<img width="1015" alt="image" src="https://github.com/user-attachments/assets/de8b723b-8186-4632-8f94-02fdcd5cf1a7" />


### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
