### PR TITLE
DCMAW-13559 PR 1 - Log proof jwt header

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential/ProofJwtService.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential/ProofJwtService.java
@@ -10,6 +10,8 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.proc.BadJWTException;
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.di.mobile.wallet.cri.services.ConfigurationService;
 
 import java.security.NoSuchAlgorithmException;
@@ -18,8 +20,6 @@ import java.security.spec.InvalidKeySpecException;
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.HashSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ProofJwtService {
 
@@ -75,7 +75,6 @@ public class ProofJwtService {
 
         // Logging the ProofJWT Header
         LOGGER.info("*** ProofJWT HEADER: {}", proofJwt.getHeader().toJSONObject());
-
     }
 
     /**


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->

- Add a log to check that the Proof JWT header contains the typ parameter

### Why did it change
<!-- Describe the reason these changes were made -->
The [OID4VCI specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-8.2.1.1) requires that the proof of possession JWT includes a typ header parameter with the value "openid4vci-proof+jwt". This logging is part of the implementations that aims to update the Credential API to validate the presence and value of this parameter during proof of possession verification.
### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-13559](https://govukverify.atlassian.net/browse/DCMAW-13559)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->
<img width="800" alt="Screenshot 2025-06-12 at 12 15 21" src="https://github.com/user-attachments/assets/0465d568-eeeb-4d4e-a8d0-08d10e1052e8" />

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-13559]: https://govukverify.atlassian.net/browse/DCMAW-13559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ