### PR TITLE
DCMAW-13823: Reference build secrets in workflow

### DIFF
--- a/.github/workflows/document-signing-cerificate-issuer-push-to-main.yml
+++ b/.github/workflows/document-signing-cerificate-issuer-push-to-main.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
-          role-to-assume: ${{ secrets.DEV_DSC_ISS_GH_ACTIONS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.BUILD_DSC_ISS_GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
       - name: Set up SAM CLI
@@ -50,7 +50,7 @@ jobs:
       - name: Upload artifacts
         uses: govuk-one-login/devplatform-upload-action@720ddb75fba8951db5a648ebb416eb233f1b6bc9 # pin@v3.10.1
         with:
-          artifact-bucket-name: ${{ secrets.DEV_DSC_ISS_ARTIFACT_SOURCE_BUCKET_NAME }}
-          signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
+          artifact-bucket-name: ${{ secrets.BUILD_DSC_ISS_ARTIFACT_SOURCE_BUCKET_NAME }}
+          signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
           working-directory: ./document-signing-certificate-issuer
           template-file: .aws-sam/build/template.yaml


### PR DESCRIPTION
## Proposed changes
### What changed
- Reference build environment secrets in the workflow which runs when a PR is merged into main.

### Why did it change
- Once a PR is merged, the pull request workflow will attempt to deploy the application to the build environment; therefore, the workflow needs access to the secrets for that specific environment.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-13823](https://govukverify.atlassian.net/browse/DCMAW-13823)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-13823]: https://govukverify.atlassian.net/browse/DCMAW-13823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ