### PR TITLE
DCMAW-13823: IssueDocSigningCertificateFunction depends on its log group 

### DIFF
--- a/document-signing-certificate-issuer/template.yaml
+++ b/document-signing-certificate-issuer/template.yaml
@@ -135,6 +135,8 @@ Globals:
 Resources:
   IssueDocSigningCertificateFunction:
     Type: AWS::Serverless::Function
+    DependsOn:
+      - IssueDocSigningCertificateFunctionLogGroup
     Properties:
       FunctionName: !Sub ${AWS::StackName}-issue-doc-signing-certificate
       Handler: issueDocumentSigningCertificate.handler


### PR DESCRIPTION
## Proposed changes
### What changed
- Make `IssueDocSigningCertificateFunction` Lambda dependant on its log group.

### Why did it change
- This ensures that the Lambda function resource is created only after the specified log group (i.e. `IssueDocSigningCertificateFunctionLogGroup`) has been created. 

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-13823](https://govukverify.atlassian.net/browse/DCMAW-13823)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-13823]: https://govukverify.atlassian.net/browse/DCMAW-13823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ