### PR TITLE
DCMAW-13823: Remove LoggingConfig from IssueDocSigningCertificateFunction

### DIFF
--- a/document-signing-certificate-issuer/template.yaml
+++ b/document-signing-certificate-issuer/template.yaml
@@ -143,8 +143,6 @@ Resources:
       Timeout: 15
       MemorySize: 512
       ReservedConcurrentExecutions: 1
-      LoggingConfig:
-        LogGroup: !Ref IssueDocSigningCertificateFunctionLogGroup
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: issueDocSigningCertificateFunction


### PR DESCRIPTION
## Proposed changes
### What changed
- Remove `LoggingConfig` from the `IssueDocSigningCertificateFunction` Lambda definition.

### Why did it change
- `LoggingConfig` is optional and by omitting it, the Lambda will use the default logging configuration, which sends logs to the default log group `/aws/lambda/<function name>` in CloudWatch Logs. Hopefully this will solve the issue below encountered while trying to deploy the application to build:

<img width="850" alt="image" src="https://github.com/user-attachments/assets/942c2819-1f4e-41d6-8f7f-0d276a7e5127" />


### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-13823](https://govukverify.atlassian.net/browse/DCMAW-13823)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-13823]: https://govukverify.atlassian.net/browse/DCMAW-13823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ