### PR TITLE
DCMAW-13823: Set CloudWatch log retention days to 3653 in build

### DIFF
--- a/document-signing-certificate-issuer/template.yaml
+++ b/document-signing-certificate-issuer/template.yaml
@@ -61,7 +61,7 @@ Mappings:
       PlatformCaArnParameter: '/platform-ca/iaca/certificate-authority-arn'
       PlatformCaIssuerAlternativeName: '/platform-ca/iaca/issuer-alternative-name'
       RootCertificate: '/platform-ca/iaca/root-certificate'
-      CloudwatchLogRetentionDays: 3650 # 10 years, since the underlying CA root will likely have a 9 year lifecycle
+      CloudwatchLogRetentionDays: 3653 # 10 years, since the underlying CA root will likely have a 9 year lifecycle
       DynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       LambdaLogLevel: INFO
       CertificateValidityPeriodInDays: 458 # 366 (1 year) + 92 (3 months), worse case


### PR DESCRIPTION
## Proposed changes
### What changed
- Set CloudWatch log retention days to 3653 in the build environment

### Why did it change
- 3650 is not an allowed value as per the documentation: 

_RetentionInDays
The number of days to retain the log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, and 3653._

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->
- [DCMAW-13823](https://govukverify.atlassian.net/browse/DCMAW-13823)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-13823]: https://govukverify.atlassian.net/browse/DCMAW-13823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ