### PR TITLE
DCMAW-13554 Update the @context property in the DID document

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/did_document/DidDocumentService.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/did_document/DidDocumentService.java
@@ -15,7 +15,7 @@ public class DidDocumentService {
     private static final String VERIFICATION_METHOD_TYPE = "JsonWebKey2020";
     private static final String CONTROLLER_PREFIX = "did:web:";
     private static final List<String> CONTEXT =
-            List.of("https://www.w3.org/ns/did/v1", "https://www.w3.org/ns/security/jwk/v1");
+            List.of("https://www.w3.org/ns/did/v1", "https://w3id.org/security/suites/jws-2020/v1");
     private final ConfigurationService configurationService;
     private final KeyProvider keyProvider;
 

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/did_document/DidDocumentServiceTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/did_document/DidDocumentServiceTest.java
@@ -46,7 +46,7 @@ class DidDocumentServiceTest {
     private static final String TEST_CONTROLLER = "did:web:test-example-credential-issuer.gov.uk";
     private static final String TEST_DID_ID = TEST_CONTROLLER + "#" + TEST_KEY_ID;
     private static final List<String> TEST_CONTEXT =
-            List.of("https://www.w3.org/ns/did/v1", "https://www.w3.org/ns/security/jwk/v1");
+            List.of("https://www.w3.org/ns/did/v1", "https://w3id.org/security/suites/jws-2020/v1");
     private static final String TEST_DID_TYPE = "JsonWebKey2020";
     private static final String TEST_PUBLIC_KEY_TYPE = "EC";
 


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->

- Updated  one of the values of `@context` property to be `"https://w3id.org/security/suites/jws-2020/v1"`

### Why did it change
<!-- Describe the reason these changes were made -->
The current DID document returned by the did:web API uses an incorrect value for the @context property. This needs to be updated to align with the [did:web method specification](https://w3c-ccg.github.io/did-method-web/).
### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-13554](https://govukverify.atlassian.net/browse/DCMAW-13554)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->
##### Tested locally
<img width="898" alt="Screenshot 2025-07-02 at 12 48 13" src="https://github.com/user-attachments/assets/8e2984a0-7cda-4b1b-aed1-de994db7205a" />


## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-13554]: https://govukverify.atlassian.net/browse/DCMAW-13554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ