### PR TITLE
DCMAW-14318: Remove unused SAM template outputs

### DIFF
--- a/document-signing-certificate-issuer/template.yaml
+++ b/document-signing-certificate-issuer/template.yaml
@@ -249,15 +249,3 @@ Resources:
     Properties:
       AliasName: !Sub 'alias/${AWS::StackName}-doc-signing-key-1'
       TargetKeyId: !Ref DocumentSigningKey1
-
-Outputs:
-  CertificatesBucketName:
-    Description: 'The name of the S3 bucket where the certificates are stored'
-    Value: !Ref DocSigningCertificateBucket
-    Export:
-      Name: !Sub '${AWS::StackName}-CertificatesBucketName'
-  DocumentSigningKey1Arn:
-    Description: 'The ARN of the Document Signing Key 1'
-    Value: !GetAtt DocumentSigningKey1.Arn
-    Export:
-      Name: !Sub '${AWS::StackName}-DocumentSigningKey1Arn'


### PR DESCRIPTION
## Proposed changes
### What changed
Remove unused outputs from Document Signing Certificate SAM template

### Why did it change
Because these are no longer imported in the CRI SAM template.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-14318](https://govukverify.atlassian.net/browse/DCMAW-14318)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-14318]: https://govukverify.atlassian.net/browse/DCMAW-14318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ