### PR TITLE
DCMAW-13389:  Add DeviceKeyInfo to MSO

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential/ProofJwtService.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential/ProofJwtService.java
@@ -189,7 +189,7 @@ public class ProofJwtService {
      * from the JWT into a structured object.
      *
      * @param proofJwt The verified Proof JWT
-     * @param publicKey The public key
+     * @param publicKey The public key from the did:key
      * @return ProofJwtData containing the extracted information
      * @throws ProofJwtValidationException On error parsing the JWT claims
      */

--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/MobileDrivingLicenceService.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/MobileDrivingLicenceService.java
@@ -40,6 +40,7 @@ public class MobileDrivingLicenceService {
      * document and returns it as a hexadecimal string.
      *
      * @param drivingLicenceDocument The driving licence document containing user information
+     * @param publicKey The public key from the proof's did:key
      * @return A hexadecimal string representation of the CBOR-encoded mobile driving licence
      */
     public String createMobileDrivingLicence(


### PR DESCRIPTION
## Proposed changes
### What changed

**Add DeviceKeyInfo to MSO:**
- Add decoded did:key as `ECPublicKey` to `ProofJwtData` so that it can be passed to the `MobileDrivingLicenceService` where it's needed
- Add new factory `COSEKeyFactory` to build the `COSEKey` object from the `ECPublicKey`
- Add `BigIntegerToFixedBytes` helper to convert the public key x and y coordinates from `BigInteger` to fixed-length byte array
- Build `KeyAuthorizations` array from namespaces 
- Build `DeviceKeyInfo` and add it to `MobileSecurityObject`
- Extract logic to build `ValidityInfo` from `MobileSecurityObjectFactory` into a new factory: `ValidityInfoFactory`

### Why did it change
- To add the `DeviceKeyInfo` to the `MobileSecurityObject`

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-13389](https://govukverify.atlassian.net/browse/DCMAW-13389)

## Testing
Deployed to and tested in the development environment. 

<img width="1432" height="836" alt="image" src="https://github.com/user-attachments/assets/d49f04f7-0ab0-4cf6-aa2f-484bbd8afce8" />

## Checklist
- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-13389]: https://govukverify.atlassian.net/browse/DCMAW-13389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ