### PR TITLE
DCMAW-14654: Correct mDL domestic namespace

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/DrivingLicenceDocument.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/DrivingLicenceDocument.java
@@ -23,10 +23,10 @@ public class DrivingLicenceDocument {
     @Namespace(NamespaceTypes.ISO)
     private final String givenName;
 
-    @Namespace(NamespaceTypes.UK)
+    @Namespace(NamespaceTypes.GB)
     private final String title;
 
-    @Namespace(NamespaceTypes.UK)
+    @Namespace(NamespaceTypes.GB)
     private final boolean welshLicence;
 
     @Namespace(NamespaceTypes.ISO)
@@ -77,7 +77,7 @@ public class DrivingLicenceDocument {
     @Namespace(NamespaceTypes.ISO)
     private final String unDistinguishingSign;
 
-    @Namespace(NamespaceTypes.UK)
+    @Namespace(NamespaceTypes.GB)
     private final Optional<DrivingPrivilege[]> provisionalDrivingPrivileges;
 
     @JsonCreator

--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/constants/NamespaceTypes.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/constants/NamespaceTypes.java
@@ -5,7 +5,7 @@ public final class NamespaceTypes {
     public static final String ISO = "org.iso.18013.5.1";
 
     /** The domestic (GB) namespace for Mobile Driving Licence documents. */
-    public static final String UK = "org.iso.18013.5.1.GB";
+    public static final String GB = "org.iso.18013.5.1.GB";
 
     private NamespaceTypes() {}
 }

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/DocumentFactoryTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/DocumentFactoryTest.java
@@ -17,8 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.constants.NamespaceTypes.GB;
 import static uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.constants.NamespaceTypes.ISO;
-import static uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.constants.NamespaceTypes.UK;
 
 @ExtendWith(MockitoExtension.class)
 class DocumentFactoryTest {
@@ -41,7 +41,7 @@ class DocumentFactoryTest {
         // Arrange: Create dummy namespaces map
         Map<String, List<IssuerSignedItem>> dummyNamespacesMap = new HashMap<>();
         dummyNamespacesMap.put(ISO, createDummyIssuerSignedItemList(18));
-        dummyNamespacesMap.put(UK, createDummyIssuerSignedItemList(3));
+        dummyNamespacesMap.put(GB, createDummyIssuerSignedItemList(3));
         Namespaces dummyNamespaces = new Namespaces(dummyNamespacesMap);
 
         // Arrange: Mock NamespacesFactory to return dummy NamespaceTypes
@@ -53,7 +53,7 @@ class DocumentFactoryTest {
         // Simulate IssuerSigned.nameSpaces() returning a map of String -> List<byte[]>
         Map<String, List<byte[]>> dummyEncodedNamespaces = new HashMap<>();
         dummyEncodedNamespaces.put(ISO, Collections.nCopies(18, "testCbor".getBytes()));
-        dummyEncodedNamespaces.put(UK, Collections.nCopies(3, "testCbor".getBytes()));
+        dummyEncodedNamespaces.put(GB, Collections.nCopies(3, "testCbor".getBytes()));
         when(mockIssuerSigned.nameSpaces()).thenReturn(dummyEncodedNamespaces);
         when(mockIssuerSignedFactory.build(any(Namespaces.class))).thenReturn(mockIssuerSigned);
 
@@ -64,9 +64,9 @@ class DocumentFactoryTest {
         Map<String, List<byte[]>> namespaces = result.issuerSigned().nameSpaces();
         assertEquals(2, namespaces.size(), "Should have 2 namespaces (ISO and UK)");
         assertTrue(namespaces.containsKey(ISO), "Should contain ISO namespace");
-        assertTrue(namespaces.containsKey(UK), "Should contain UK namespace");
+        assertTrue(namespaces.containsKey(GB), "Should contain UK namespace");
         assertEquals(18, namespaces.get(ISO).size(), "ISO namespace should have 18 fields");
-        assertEquals(3, namespaces.get(UK).size(), "UK namespace should have 3 fields");
+        assertEquals(3, namespaces.get(GB).size(), "UK namespace should have 3 fields");
     }
 
     private List<IssuerSignedItem> createDummyIssuerSignedItemList(int count) {

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/NamespaceFactoryTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/NamespaceFactoryTest.java
@@ -61,13 +61,13 @@ class NamespacesFactoryTest {
         Map<String, List<IssuerSignedItem>> namespaces = result.asMap();
         assertEquals(2, namespaces.size(), "Should have 2 namespaces (ISO and UK)");
         assertTrue(namespaces.containsKey(NamespaceTypes.ISO), "Should contain ISO namespace");
-        assertTrue(namespaces.containsKey(NamespaceTypes.UK), "Should contain UK namespace");
+        assertTrue(namespaces.containsKey(NamespaceTypes.GB), "Should contain UK namespace");
         assertEquals(
                 18,
                 namespaces.get(NamespaceTypes.ISO).size(),
                 "ISO namespace should have 18 fields");
         assertEquals(
-                3, namespaces.get(NamespaceTypes.UK).size(), "UK namespace should have 3 fields");
+                3, namespaces.get(NamespaceTypes.GB).size(), "UK namespace should have 3 fields");
     }
 
     /**
@@ -128,7 +128,7 @@ class NamespacesFactoryTest {
         Namespaces result = namespacesFactory.build(drivingLicenceDocument);
 
         // Assert: Check that UK namespace has correct number of fields
-        List<IssuerSignedItem> ukNamespace = result.asMap().get(NamespaceTypes.UK);
+        List<IssuerSignedItem> ukNamespace = result.asMap().get(NamespaceTypes.GB);
         assertEquals(
                 3,
                 ukNamespace.size(),
@@ -156,7 +156,7 @@ class NamespacesFactoryTest {
         Namespaces result = namespacesFactory.build(drivingLicenceDocument);
 
         // Assert: Check that UK namespace has only 1 field (i.e. not provisional privileges)
-        List<IssuerSignedItem> ukNamespace = result.asMap().get(NamespaceTypes.UK);
+        List<IssuerSignedItem> ukNamespace = result.asMap().get(NamespaceTypes.GB);
         assertEquals(
                 2,
                 ukNamespace.size(),


### PR DESCRIPTION
## Proposed changes
### What changed
- Change mDL domestic namespace from **org.iso.18013.5.1.UK** to **org.iso.18013.5.1.GB**

### Why did it change
- org.iso.18013.5.1.UK is incorrect

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-14654](https://govukverify.atlassian.net/browse/DCMAW-14654)

## Testing
Deployed to dev.

<img width="1702" height="481" alt="image" src="https://github.com/user-attachments/assets/1d8ec27f-8853-4891-94bc-2769091eee55" />


## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-14654]: https://govukverify.atlassian.net/browse/DCMAW-14654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ