### PR TITLE
fix: encode portrait as binary data in mDL

### DIFF
--- a/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/DrivingLicenceDocument.java
+++ b/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/DrivingLicenceDocument.java
@@ -7,10 +7,10 @@ import lombok.Setter;
 import uk.gov.di.mobile.wallet.cri.annotations.Namespace;
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.constants.NamespaceTypes;
 
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -106,7 +106,8 @@ public class DrivingLicenceDocument {
         this.givenName = Objects.requireNonNull(givenName, "given_name is required");
         this.title = Objects.requireNonNull(title, "title is required");
         this.welshLicence = welshLicence;
-        this.portrait = getBytes(Objects.requireNonNull(portrait, "portrait is required"));
+        this.portrait =
+                getBytesFromBase64(Objects.requireNonNull(portrait, "portrait is required"));
         this.birthDate = parseDate(Objects.requireNonNull(birthDate, "birth_date is required"));
         this.ageOver18 = getAge(this.birthDate) >= 18;
         this.ageOver21 = getAge(this.birthDate) >= 21;
@@ -141,7 +142,7 @@ public class DrivingLicenceDocument {
         return Period.between(birthDate, LocalDate.now()).getYears();
     }
 
-    private byte[] getBytes(String base64Portrait) {
-        return base64Portrait.getBytes(StandardCharsets.UTF_8);
+    private byte[] getBytesFromBase64(String base64String) {
+        return Base64.getDecoder().decode(base64String);
     }
 }

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/DrivingLicenceDocumentTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/DrivingLicenceDocumentTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.format.DateTimeParseException;
+import java.util.Base64;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -72,7 +72,7 @@ class DrivingLicenceDocumentTest {
         assertEquals(GIVEN_NAME, document.getGivenName());
         assertEquals(TITLE, document.getTitle());
         assertEquals(WELSH_LICENSE, document.isWelshLicence());
-        assertArrayEquals(PORTRAIT.getBytes(StandardCharsets.UTF_8), document.getPortrait());
+        assertArrayEquals(Base64.getDecoder().decode(PORTRAIT), document.getPortrait());
         assertEquals(LocalDate.of(1985, 5, 24), document.getBirthDate());
         assertEquals(age >= 18, document.getAgeOver18());
         assertEquals(age >= 21, document.getAgeOver21());

--- a/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/NamespaceFactoryTest.java
+++ b/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/NamespaceFactoryTest.java
@@ -10,8 +10,8 @@ import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.DrivingPriv
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.MDLException;
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.constants.NamespaceTypes;
 
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -97,9 +97,7 @@ class NamespacesFactoryTest {
         verify(mockIssuerSignedItemFactory).build("family_name", "Doe");
         verify(mockIssuerSignedItemFactory).build("given_name", "John");
         verify(mockIssuerSignedItemFactory)
-                .build(
-                        "portrait",
-                        ("base64EncodedPortraitString").getBytes(StandardCharsets.UTF_8));
+                .build("portrait", Base64.getDecoder().decode("base64EncodedPortraitString"));
         verify(mockIssuerSignedItemFactory).build("birth_date", LocalDate.parse("1985-05-24"));
         verify(mockIssuerSignedItemFactory).build("birth_place", "London");
         verify(mockIssuerSignedItemFactory).build("issue_date", LocalDate.parse("2020-01-10"));


### PR DESCRIPTION
Replaces https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/pull/283

## Proposed changes
### What changed
- The type and content of the mDL `portrait` field changed from a string (Base64 format) to the actual binary data represented as an array of bytes.

### Why did it change
- The  mDL `portrait` must be encoded as binary data and not as string/text.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-14443](https://govukverify.atlassian.net/browse/DCMAW-14443)

## Testing
Tested locally.

<img width="1708" height="964" alt="Screenshot 2025-07-15 at 17 30 28" src="https://github.com/user-attachments/assets/1bf1b155-deb7-401d-b3ac-e68c59c27439" />


## Checklist
- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-14443]: https://govukverify.atlassian.net/browse/DCMAW-14443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ