### PR TITLE
ci: add default working directory to Run Code Analysis workflow job #308

### DIFF
--- a/.github/workflows/example-credential-issuer-push-to-main.yml
+++ b/.github/workflows/example-credential-issuer-push-to-main.yml
@@ -15,6 +15,9 @@ jobs:
     name: Run Code Analysis
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: ./example-credential-issuer
     steps:
       - name: Check out repository code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->
- Add `./example-credential-issuer` as the default working directory of the CRI "Push to Main" workflow "Run Code Analysis" job

### Why did it change
- Default working directory was missing, which was causing the "Build and unit test" step of the workflow to fail

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-13975](https://govukverify.atlassian.net/browse/DCMAW-13975)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-13975]: https://govukverify.atlassian.net/browse/DCMAW-13975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ