### PR TITLE
ci: add default working directory to Deploy workflow job

### DIFF
--- a/.github/workflows/example-credential-issuer-push-to-main.yml
+++ b/.github/workflows/example-credential-issuer-push-to-main.yml
@@ -62,8 +62,10 @@ jobs:
     name: Deploy
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: ./example-credential-issuer
     needs: run-code-analysis
-
     steps:
       - name: Check out repository code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -87,7 +89,6 @@ jobs:
           cosign-release: 'v2.5.2'
 
       - name: Build, tag and push image to ECR
-        working-directory: ./example-credential-issuer
         env:
           ECR_REGISTRY: "${{ secrets.BUILD_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com"
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->
- Add `./example-credential-issuer` as the default working directory of the CRI "Push to Main" workflow "Deploy" job

### Why did it change
- Default working directory was missing, which was causing the "Update SAM template" step to fail

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-13975](https://govukverify.atlassian.net/browse/DCMAW-13975)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-13975]: https://govukverify.atlassian.net/browse/DCMAW-13975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ