### PR TITLE
ci: fix path to built SAM template

### DIFF
--- a/.github/workflows/example-credential-issuer-push-to-main.yml
+++ b/.github/workflows/example-credential-issuer-push-to-main.yml
@@ -130,4 +130,5 @@ jobs:
         with:
           artifact-bucket-name: ${{ secrets.BUILD_ENV_ARTIFACT_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
-          working-directory: ./deploy/.aws-sam/build
+          working-directory: ./example-credential-issuer/deploy
+          template-file: .aws-sam/build/template.yaml


### PR DESCRIPTION
## Proposed changes
### What changed
- Correct the path to the built SAM template

### Why did it change
- Deployment of SAM app is failing because the template can't be found

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-13975](https://govukverify.atlassian.net/browse/DCMAW-13975)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-13975]: https://govukverify.atlassian.net/browse/DCMAW-13975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ