### PR TITLE
fix: update dynamodb tables name

### DIFF
--- a/example-credential-issuer/deploy/template.yaml
+++ b/example-credential-issuer/deploy/template.yaml
@@ -636,7 +636,7 @@ Resources:
         - AttributeName: credentialIdentifier
           AttributeType: S
       BillingMode: PAY_PER_REQUEST
-      TableName: !Sub "${AWS::StackName}-credential_offer_cache_2"
+      TableName: !Sub "${AWS::StackName}-credential_offer_cache"
       KeySchema:
         - AttributeName: credentialIdentifier
           KeyType: HASH
@@ -668,7 +668,7 @@ Resources:
         - AttributeName: credentialIdentifier
           AttributeType: S
       BillingMode: PAY_PER_REQUEST
-      TableName: !Sub "${AWS::StackName}-credential_store_2"
+      TableName: !Sub "${AWS::StackName}-credential_store"
       KeySchema:
         - AttributeName: credentialIdentifier
           KeyType: HASH


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->

- Update DynamoDb `credential_offer_cache_2` table name to be `credential_offer_cache`
- Update DynamoDb `credential_store_2` table name to be `credential_store`

### Why did it change
<!-- Describe the reason these changes were made -->

This name change initially was to resolve a pipeline build issue after we renamed the resources in the template to improve code readability in this PR https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/pull/296
Now we are reverting back to the original names.


### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->
<img width="1365" height="704" alt="Screenshot 2025-08-11 at 16 27 07" src="https://github.com/user-attachments/assets/bc1e6c68-6216-4d83-a809-a7ba4b364b82" />


## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
