### PR TITLE
fix: correct invalid age_over_NN identifiers in mDL

### DIFF
--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/CamelToSnake.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/CamelToSnake.java
@@ -19,7 +19,8 @@ public final class CamelToSnake {
         if (camelCase == null || camelCase.isEmpty()) {
             return camelCase;
         }
-        String snakeCase = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, camelCase);
-        return snakeCase.replaceAll("(?<=[A-Za-z])(?=\\d)","_");
+        return CaseFormat.LOWER_CAMEL
+                .to(CaseFormat.LOWER_UNDERSCORE, camelCase)
+                .replaceAll("(?<=[A-Za-z])(?=\\d)", "_");
     }
 }


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->

- Add underscore so age attestation identifiers follow the ISO/IEC 18013-5 format: `age_over_NN` (e.g., `age_over_18`)

### Why did it change
<!-- Describe the reason these changes were made -->
The Example CRI mobile driver's license (mDL) includes age attestation elements such as age_over_18, age_over_21, and age_over_25. According to ISO/IEC 18013-5, the correct identifier format is age_over_NN with an underscore separating "over" and the numeric age value (NN). Our mdoc previously returned these identifiers without the underscore (e.g., age_over18), and this implementation is to fix that.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-14975](https://govukverify.atlassian.net/browse/DCMAW-14975)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->
##### Tested locally
<img width="619" height="671" alt="Screenshot 2025-08-13 at 19 34 27" src="https://github.com/user-attachments/assets/e02f6cf9-11b8-4cd4-b071-c51d0103e1c4" />

## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-14975]: https://govukverify.atlassian.net/browse/DCMAW-14975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ