### PR TITLE
fix: date-time string CBOR tag

### DIFF
--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cbor/InstantCBORSerializer.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cbor/InstantCBORSerializer.java
@@ -24,8 +24,8 @@ public class InstantCBORSerializer extends JsonSerializer<Instant> {
         }
         String formatted =
                 instant.truncatedTo(ChronoUnit.SECONDS).toString(); // "2026-06-24T16:05:21Z"
-        // '1000' is a tag indicating that the CBOR value should be interpreted as a date-time
-        cborGenerator.writeTag(1000);
+        // '0' is a tag indicating that the CBOR value should be interpreted as a date-time
+        cborGenerator.writeTag(0);
         generator.writeString(formatted);
     }
 }

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cbor/InstantCBORSerializerTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cbor/InstantCBORSerializerTest.java
@@ -36,7 +36,7 @@ class InstantCBORSerializerTest {
 
         serializer.serialize(testDate, cborGenerator, serializerProvider);
 
-        verify(cborGenerator).writeTag(1000);
+        verify(cborGenerator).writeTag(0);
         verify(cborGenerator).writeString(expectedDateString);
     }
 


### PR DESCRIPTION
## Proposed changes
### What changed
- Change date-time string tag from `1000` to `0`.

### Why did it change
- To comply with ISO/IEC 18013-5.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-14999](https://govukverify.atlassian.net/browse/DCMAW-14999)

## Testing
Tested locally.
<img width="1490" height="1062" alt="Screenshot 2025-08-14 at 17 09 59" src="https://github.com/user-attachments/assets/ae734d90-8914-490d-9131-ae1ceaa304ac" />

<img width="1429" height="1068" alt="Screenshot 2025-08-14 at 17 12 23" src="https://github.com/user-attachments/assets/1ce71a34-8158-4f40-8a9d-08fa803fda9e" />



## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-14999]: https://govukverify.atlassian.net/browse/DCMAW-14999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ