### PR TITLE
fix: invalid identifiers in `driving_privileges` and `provisional_driving_privileges`

### DIFF
--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/DrivingLicenceDocument.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/DrivingLicenceDocument.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 import java.time.Period;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -73,13 +74,13 @@ public class DrivingLicenceDocument {
     private final String residentCity;
 
     @Namespace(NamespaceTypes.ISO)
-    private final DrivingPrivilege[] drivingPrivileges;
+    private final List<DrivingPrivilege> drivingPrivileges;
 
     @Namespace(NamespaceTypes.ISO)
     private final String unDistinguishingSign;
 
     @Namespace(NamespaceTypes.GB)
-    private final Optional<DrivingPrivilege[]> provisionalDrivingPrivileges;
+    private final Optional<List<DrivingPrivilege>> provisionalDrivingPrivileges;
 
     @JsonCreator
     public DrivingLicenceDocument(
@@ -98,10 +99,10 @@ public class DrivingLicenceDocument {
             @JsonProperty("resident_address") String[] residentAddress,
             @JsonProperty("resident_postal_code") String residentPostalCode,
             @JsonProperty("resident_city") String residentCity,
-            @JsonProperty("driving_privileges") DrivingPrivilege[] drivingPrivileges,
+            @JsonProperty("driving_privileges") List<DrivingPrivilege> drivingPrivileges,
             @JsonProperty("un_distinguishing_sign") String unDistinguishingSign,
             @JsonProperty("provisional_driving_privileges")
-                    DrivingPrivilege[] provisionalDrivingPrivileges) {
+                    List<DrivingPrivilege> provisionalDrivingPrivileges) {
         this.familyName = Objects.requireNonNull(familyName, "family_name is required");
         this.givenName = Objects.requireNonNull(givenName, "given_name is required");
         this.title = Objects.requireNonNull(title, "title is required");

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/NamespacesFactory.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/NamespacesFactory.java
@@ -6,7 +6,13 @@ import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.MDLExceptio
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.CamelToSnake.camelToSnake;

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/DrivingLicenceDocumentTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/DrivingLicenceDocumentTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.format.DateTimeParseException;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -34,13 +36,11 @@ class DrivingLicenceDocumentTest {
     private static final String[] RESIDENT_ADDRESS = {"123 Main St", "Apt 4B"};
     private static final String RESIDENT_POSTAL_CODE = "SW1A 1AA";
     private static final String RESIDENT_CITY = "London";
-    private static final DrivingPrivilege[] DRIVING_PRIVILEGES = {
-        mock(DrivingPrivilege.class), mock(DrivingPrivilege.class)
-    };
+    private static final List<DrivingPrivilege> DRIVING_PRIVILEGES =
+            Arrays.asList(mock(DrivingPrivilege.class), mock(DrivingPrivilege.class));
     private static final String UN_DISTINGUISHING_SIGN = "UK";
-    private static final DrivingPrivilege[] PROVISIONAL_DRIVING_PRIVILEGES = {
-        mock(DrivingPrivilege.class), mock(DrivingPrivilege.class)
-    };
+    private static final List<DrivingPrivilege> PROVISIONAL_DRIVING_PRIVILEGES =
+            Arrays.asList(mock(DrivingPrivilege.class), mock(DrivingPrivilege.class));
 
     @Test
     void Should_CreateInstance_When_DataIsValid() {
@@ -86,7 +86,7 @@ class DrivingLicenceDocumentTest {
         assertEquals("123 Main St, Apt 4B", document.getResidentAddress());
         assertEquals(RESIDENT_POSTAL_CODE, document.getResidentPostalCode());
         assertEquals(RESIDENT_CITY, document.getResidentCity());
-        assertArrayEquals(DRIVING_PRIVILEGES, document.getDrivingPrivileges());
+        assertEquals(DRIVING_PRIVILEGES, document.getDrivingPrivileges());
     }
 
     @Test
@@ -147,7 +147,7 @@ class DrivingLicenceDocumentTest {
 
     @Test
     void Should_CreateInstance_When_ProvisionalDrivingPrivilegesIsNull() {
-        DrivingPrivilege[] provisionalDrivingPrivileges = null;
+        List<DrivingPrivilege> provisionalDrivingPrivileges = null;
 
         DrivingLicenceDocument document =
                 new DrivingLicenceDocument(

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/NamespaceFactoryTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/NamespaceFactoryTest.java
@@ -11,7 +11,6 @@ import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.MDLExceptio
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.constants.NamespaceTypes;
 
 import java.time.LocalDate;
-import java.util.*;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/NamespaceFactoryTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/NamespaceFactoryTest.java
@@ -16,13 +16,11 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
## Proposed changes
### What changed
- Convert the field names () inside the `DrivingPrivilege` object to be in snake case, so that: `vehicleCategoryCode` > `vehicle_category_code`, `issueDate` > `issue_date` and `expiryDate` > `expiry_date`.

### Why did it change
- Fields names must be in snake case as per ISO 18013-5 standard. 

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-15000](https://govukverify.atlassian.net/browse/DCMAW-15000)

## Testing
Tested in dev.
<img width="2021" height="797" alt="Screenshot 2025-08-15 at 15 19 07" src="https://github.com/user-attachments/assets/51ed5edb-d94b-4b26-b886-106c6c6b1cbf" />

<img width="2021" height="797" alt="Screenshot 2025-08-15 at 15 19 31" src="https://github.com/user-attachments/assets/87adf2ca-809d-4229-afd1-988d87f968f4" />


## Checklist
- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-15000]: https://govukverify.atlassian.net/browse/DCMAW-15000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ