### PR TITLE
chore: add sigstore/cosign-installer commit SHA hash

### DIFF
--- a/.github/workflows/example-credential-issuer-push-to-main.yml
+++ b/.github/workflows/example-credential-issuer-push-to-main.yml
@@ -86,7 +86,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
         with:
           cosign-release: 'v2.5.2'
 


### PR DESCRIPTION
## Proposed changes
### What changed
- Use full commit SHA hash with sigstore/cosign-installer

### Why did it change
<!-- Describe the reason these changes were made -->

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
