### PR TITLE
fix: add `jti` and `exp` to access token validation

### DIFF
--- a/example-credential-issuer/src/test/java/testUtils/MockAccessTokenBuilder.java
+++ b/example-credential-issuer/src/test/java/testUtils/MockAccessTokenBuilder.java
@@ -20,6 +20,8 @@ public class MockAccessTokenBuilder {
                             "urn:fdc:wallet.account.gov.uk:2024:DtPT8x-dp_73tnlY3KNTiCitziN9GEherD16bqxNt9i")
                     .audience("https://issuer-url.gov.uk")
                     .issuer("https://auth-url.gov.uk")
+                    .jwtID("e75b7cc0-c5ef-4075-ad22-3b239b6db89c")
+                    .expirationTime(Date.from(Instant.now().plusSeconds(180)))
                     .claim("c_nonce", "134e0c41-a8b4-46d4-aec8-cd547e125589")
                     .claim(
                             "credential_identifiers",
@@ -49,6 +51,11 @@ public class MockAccessTokenBuilder {
 
     public MockAccessTokenBuilder withAudience(String audience) {
         claimsBuilder.audience(audience);
+        return this;
+    }
+
+    public MockAccessTokenBuilder withExpirationTime(Date expirationTime) {
+        claimsBuilder.expirationTime(expirationTime);
         return this;
     }
 

--- a/example-credential-issuer/src/test/java/testUtils/MockAccessTokenBuilder.java
+++ b/example-credential-issuer/src/test/java/testUtils/MockAccessTokenBuilder.java
@@ -15,7 +15,6 @@ public class MockAccessTokenBuilder {
     private final JWSHeader.Builder headerBuilder;
     private final JWTClaimsSet.Builder claimsBuilder =
             new JWTClaimsSet.Builder()
-                    .issueTime(Date.from(Instant.now()))
                     .subject(
                             "urn:fdc:wallet.account.gov.uk:2024:DtPT8x-dp_73tnlY3KNTiCitziN9GEherD16bqxNt9i")
                     .audience("https://issuer-url.gov.uk")

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/services/authentication/AccessTokenServiceTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/services/authentication/AccessTokenServiceTest.java
@@ -14,6 +14,8 @@ import uk.gov.di.mobile.wallet.cri.services.ConfigurationService;
 import uk.gov.di.mobile.wallet.cri.services.JwksService;
 
 import java.text.ParseException;
+import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -105,8 +107,24 @@ class AccessTokenServiceTest {
                         AccessTokenValidationException.class,
                         () -> accessTokenService.verifyAccessToken(mockAccessToken));
         assertEquals(
-                "JWT missing required claims: [aud, c_nonce, credential_identifiers, iss, sub]",
+                "JWT missing required claims: [aud, c_nonce, credential_identifiers, exp, iss, jti, sub]",
                 exception.getMessage());
+    }
+
+    @Test
+    void Should_ThrowAccessTokenValidationException_When_TokenIsExpired() {
+        SignedJWT mockAccessToken =
+                new MockAccessTokenBuilder("ES256")
+                        .withExpirationTime(
+                                Date.from(
+                                        Instant.now().minusSeconds(180))) // Expired 180 seconds ago
+                        .build();
+
+        AccessTokenValidationException exception =
+                assertThrows(
+                        AccessTokenValidationException.class,
+                        () -> accessTokenService.verifyAccessToken(mockAccessToken));
+        assertEquals("Expired JWT", exception.getMessage());
     }
 
     @Test

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/services/authentication/AccessTokenServiceTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/services/authentication/AccessTokenServiceTest.java
@@ -16,7 +16,8 @@ import uk.gov.di.mobile.wallet.cri.services.JwksService;
 import java.text.ParseException;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
## Proposed changes
### What changed
- Add `jti` and `exp` to access token claims validation.

### Why did it change
- These claims are required and the issuer must check that they are present and the token is not expired.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-15228](https://govukverify.atlassian.net/browse/DCMAW-15228)

## Testing
- Unit testing only

## Checklist
- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
https://github.com/govuk-one-login/mobile-wallet-tech-docs/pull/136
https://github.com/govuk-one-login/mobile-wallet-cri-test-harness/pull/317
https://github.com/govuk-one-login/mobile-wallet-document-builder/pull/293



[DCMAW-15228]: https://govukverify.atlassian.net/browse/DCMAW-15228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ