### PR TITLE
feat: add DeviceKeyInfo to MSO

### DIFF
--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/ServicesFactory.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/ServicesFactory.java
@@ -13,12 +13,14 @@ import uk.gov.di.mobile.wallet.cri.credential.ProofJwtService;
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.MobileDrivingLicenceService;
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cbor.CBOREncoder;
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cbor.JacksonCBOREncoderProvider;
+import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose.COSEKeyFactory;
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose.COSESigner;
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.DigestIDGenerator;
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.IssuerSignedFactory;
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.IssuerSignedItemFactory;
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.MobileSecurityObjectFactory;
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.NamespacesFactory;
+import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.ValidityInfoFactory;
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.ValueDigestsFactory;
 import uk.gov.di.mobile.wallet.cri.credential_offer.CredentialOfferService;
 import uk.gov.di.mobile.wallet.cri.credential_offer.PreAuthorizedCodeBuilder;
@@ -95,8 +97,11 @@ public class ServicesFactory {
                 new IssuerSignedItemFactory(new DigestIDGenerator());
         ValueDigestsFactory valueDigestsFactory =
                 new ValueDigestsFactory(cborEncoder, MessageDigest.getInstance("SHA-256"));
+        ValidityInfoFactory validityInfoFactory = new ValidityInfoFactory();
+        COSEKeyFactory coseKeyFactory = new COSEKeyFactory();
         MobileSecurityObjectFactory mobileSecurityObjectFactory =
-                new MobileSecurityObjectFactory(valueDigestsFactory);
+                new MobileSecurityObjectFactory(
+                        valueDigestsFactory, validityInfoFactory, coseKeyFactory);
         COSESigner coseSigner =
                 new COSESigner(
                         cborEncoder, kmsService, configurationService.getDocumentSigningKey1Arn());

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/CredentialService.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/CredentialService.java
@@ -26,6 +26,7 @@ import uk.gov.di.mobile.wallet.cri.services.signing.SigningException;
 import uk.gov.di.mobile.wallet.cri.util.ExpiryUtil;
 
 import java.security.cert.CertificateException;
+import java.security.interfaces.ECPublicKey;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Objects;
@@ -139,7 +140,8 @@ public class CredentialService {
             } else if (Objects.equals(vcType, MOBILE_DRIVING_LICENCE.getType())) {
                 DrivingLicenceDocument drivingLicenceDocument =
                         mapper.convertValue(document.getData(), DrivingLicenceDocument.class);
-                credential = getMobileDrivingLicence(drivingLicenceDocument);
+                credential =
+                        getMobileDrivingLicence(drivingLicenceDocument, proofJwtData.publicKey());
                 LocalDate expiryDate = drivingLicenceDocument.getExpiryDate();
                 documentExpiry = ExpiryUtil.calculateExpiryTimeFromDate(expiryDate);
 
@@ -219,9 +221,11 @@ public class CredentialService {
                         veteranCardDocument.getCredentialTtlMinutes());
     }
 
-    private String getMobileDrivingLicence(DrivingLicenceDocument drivingLicenceDocument)
+    private String getMobileDrivingLicence(
+            DrivingLicenceDocument drivingLicenceDocument, ECPublicKey publicKey)
             throws ObjectStoreException, SigningException, CertificateException {
-        return mobileDrivingLicenceService.createMobileDrivingLicence(drivingLicenceDocument);
+        return mobileDrivingLicenceService.createMobileDrivingLicence(
+                drivingLicenceDocument, publicKey);
     }
 
     protected Logger getLogger() {

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/ProofJwtService.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/ProofJwtService.java
@@ -22,16 +22,35 @@ import java.text.ParseException;
 import java.util.Arrays;
 import java.util.HashSet;
 
+/**
+ * Service for verifying OpenID4VCI Proof JWTs.
+ *
+ * <p>This service handles the verification of Proof JWTs used in OpenID4VCI flows, including header
+ * validation, payload claims verification, and signature verification using DID key resolution.
+ */
 public class ProofJwtService {
 
     public static final String NONCE = "nonce";
     private static final JWSAlgorithm EXPECTED_SIGNING_ALGORITHM = JWSAlgorithm.parse("ES256");
     private static final String EXPECTED_ISSUER = "urn:fdc:gov:uk:wallet";
+    private static final String EXPECTED_JWT_TYPE = "openid4vci-proof+jwt";
 
     private final ConfigurationService configurationService;
 
-    public record ProofJwtData(String didKey, String nonce) {}
+    /**
+     * Data container for verified Proof JWT information.
+     *
+     * @param didKey The did:key from the JWT header
+     * @param nonce The nonce value from the JWT payload
+     * @param publicKey The resolved EC public key from the did:key
+     */
+    public record ProofJwtData(String didKey, String nonce, ECPublicKey publicKey) {}
 
+    /**
+     * Constructs a new ProofJwtService with the specified configuration service.
+     *
+     * @param configurationService The configuration service for retrieving application settings
+     */
     public ProofJwtService(ConfigurationService configurationService) {
         this.configurationService = configurationService;
     }
@@ -40,50 +59,58 @@ public class ProofJwtService {
      * Verifies the Proof JWT header and payload claims and its signature.
      *
      * @param proofJwt The Proof JWT to verify
-     * @return ProofJwtData
+     * @return ProofJwtData containing the did:key, nonce, and public key
      * @throws ProofJwtValidationException On any error verifying the token claims and signature
      */
     public ProofJwtData verifyProofJwt(SignedJWT proofJwt) throws ProofJwtValidationException {
         verifyTokenHeader(proofJwt);
         verifyTokenClaims(proofJwt);
-        if (!this.verifyTokenSignature(proofJwt)) {
+
+        String didKey = proofJwt.getHeader().getKeyID();
+        ECPublicKey publicKey = getPublicKey(didKey);
+
+        if (!verifyTokenSignature(proofJwt, publicKey)) {
             throw new ProofJwtValidationException("Proof JWT signature verification failed");
         }
 
-        return extractProofJwtData(proofJwt);
+        return extractProofJwtData(proofJwt, publicKey);
     }
 
     /**
-     * Verifies that the required header claims are present and/or match an expected value.
+     * Verifies that the required header claims are present and match expected values.
      *
      * @param proofJwt The Proof JWT to validate
      * @throws ProofJwtValidationException On invalid header claims
      */
     private void verifyTokenHeader(SignedJWT proofJwt) throws ProofJwtValidationException {
+        JWSHeader header = proofJwt.getHeader();
 
-        JWSAlgorithm jwtAlgorithm = proofJwt.getHeader().getAlgorithm();
-        if (jwtAlgorithm != EXPECTED_SIGNING_ALGORITHM) {
+        JWSAlgorithm jwtAlgorithm = header.getAlgorithm();
+        if (!EXPECTED_SIGNING_ALGORITHM.equals(jwtAlgorithm)) {
             throw new ProofJwtValidationException(
                     String.format(
-                            "JWT alg header claim [%s] does not match client config alg [%s]",
+                            "JWT alg header claim [%s] does not match expected algorithm [%s]",
                             jwtAlgorithm, EXPECTED_SIGNING_ALGORITHM));
         }
 
-        if (proofJwt.getHeader().getKeyID() == null) {
+        if (header.getKeyID() == null) {
             throw new ProofJwtValidationException("JWT kid header claim is null");
         }
 
-        JOSEObjectType typ = proofJwt.getHeader().getType();
+        JOSEObjectType typ = header.getType();
         if (typ == null) {
             throw new ProofJwtValidationException("JWT type header claim is null");
         }
-        if (!"openid4vci-proof+jwt".equals(typ.toString())) {
-            throw new ProofJwtValidationException("JWT type header claim is invalid");
+        if (!EXPECTED_JWT_TYPE.equals(typ.toString())) {
+            throw new ProofJwtValidationException(
+                    String.format(
+                            "JWT type header claim [%s] does not match expected type [%s]",
+                            typ, EXPECTED_JWT_TYPE));
         }
     }
 
     /**
-     * Verifies that the required payload claims are present and/or match an expected value.
+     * Verifies that the required payload claims are present and match expected values.
      *
      * @param proofJwt The Proof JWT to validate
      * @throws ProofJwtValidationException On invalid payload claims
@@ -108,42 +135,74 @@ public class ProofJwtService {
     }
 
     /**
-     * Verifies the Proof JWT signature with the public key extracted from the did:key included in
-     * the token's "kid" header claim.
+     * Extracts the EC public key from the did:key.
      *
-     * @param proofJwt The Proof JWT to verify
-     * @throws ProofJwtValidationException On error verifying the token signature
+     * @param didKey The did:key to resolve
+     * @return The EC public key
+     * @throws ProofJwtValidationException On error resolving the did:key or generating the public
+     *     key
      */
-    private boolean verifyTokenSignature(SignedJWT proofJwt) throws ProofJwtValidationException {
-        String didKey = proofJwt.getHeader().getKeyID();
+    private ECPublicKey getPublicKey(String didKey) throws ProofJwtValidationException {
         try {
             DidKeyResolver didKeyResolver = new DidKeyResolver();
             DidKeyResolver.DecodedKeyData resolvedDidKey = didKeyResolver.decodeDidKey(didKey);
             byte[] rawPublicKeyBytes = resolvedDidKey.rawPublicKeyBytes();
-            ECPublicKey publicKey = didKeyResolver.generatePublicKeyFromBytes(rawPublicKeyBytes);
+            return didKeyResolver.generatePublicKeyFromBytes(rawPublicKeyBytes);
+        } catch (NoSuchAlgorithmException
+                | InvalidKeySpecException
+                | InvalidDidKeyException exception) {
+            throw new ProofJwtValidationException(
+                    String.format(
+                            "Error getting public key from did:key [%s]: %s",
+                            didKey, exception.getMessage()),
+                    exception);
+        }
+    }
+
+    /**
+     * Verifies the Proof JWT signature using the provided public key.
+     *
+     * <p>Creates an ECDSA verifier with the P-256 curve and verifies the JWT signature.
+     *
+     * @param proofJwt The Proof JWT to verify
+     * @param publicKey The EC public key to use for signature verification
+     * @return true if the signature is valid, false otherwise
+     * @throws ProofJwtValidationException On error during signature verification
+     */
+    private boolean verifyTokenSignature(SignedJWT proofJwt, ECPublicKey publicKey)
+            throws ProofJwtValidationException {
+        try {
             ECKey ecKey = new ECKey.Builder(Curve.P_256, publicKey).build();
             ECDSAVerifier verifier = new ECDSAVerifier(ecKey);
             return proofJwt.verify(verifier);
-        } catch (JOSEException
-                | IllegalArgumentException
-                | NoSuchAlgorithmException
-                | InvalidKeySpecException
-                | InvalidDidKeyException exception) {
+        } catch (JOSEException exception) {
             throw new ProofJwtValidationException(
                     String.format("Error verifying signature: %s", exception.getMessage()),
                     exception);
         }
     }
 
-    private static ProofJwtData extractProofJwtData(SignedJWT token)
+    /**
+     * Extracts data from the verified Proof JWT.
+     *
+     * <p>This method is called after successful verification to extract the relevant information
+     * from the JWT into a structured object.
+     *
+     * @param proofJwt The verified Proof JWT
+     * @param publicKey The public key from the did:key
+     * @return ProofJwtData containing the extracted information
+     * @throws ProofJwtValidationException On error parsing the JWT claims
+     */
+    private static ProofJwtData extractProofJwtData(SignedJWT proofJwt, ECPublicKey publicKey)
             throws ProofJwtValidationException {
         try {
-            JWSHeader header = token.getHeader();
-            JWTClaimsSet claimsSet = token.getJWTClaimsSet();
-
-            return new ProofJwtData(header.getKeyID(), claimsSet.getStringClaim(NONCE));
+            JWSHeader header = proofJwt.getHeader();
+            JWTClaimsSet claimsSet = proofJwt.getJWTClaimsSet();
+            return new ProofJwtData(header.getKeyID(), claimsSet.getStringClaim(NONCE), publicKey);
         } catch (ParseException exception) {
-            throw new ProofJwtValidationException(exception.getMessage(), exception);
+            throw new ProofJwtValidationException(
+                    String.format("Error extracting Proof JWT data: %s", exception.getMessage()),
+                    exception);
         }
     }
 }

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/MobileDrivingLicenceService.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/MobileDrivingLicenceService.java
@@ -9,6 +9,7 @@ import uk.gov.di.mobile.wallet.cri.services.object_storage.ObjectStoreException;
 import uk.gov.di.mobile.wallet.cri.services.signing.SigningException;
 
 import java.security.cert.CertificateException;
+import java.security.interfaces.ECPublicKey;
 import java.util.Base64;
 
 /**
@@ -44,10 +45,11 @@ public class MobileDrivingLicenceService {
      * @param drivingLicenceDocument The driving licence data to serialise and sign
      * @return A Base64URL-encoded string containing the CBOR-encoded {@code IssuerSigned} structure
      */
-    public String createMobileDrivingLicence(DrivingLicenceDocument drivingLicenceDocument)
+    public String createMobileDrivingLicence(
+            DrivingLicenceDocument drivingLicenceDocument, ECPublicKey publicKey)
             throws ObjectStoreException, SigningException, CertificateException {
         Namespaces namespaces = namespacesFactory.build(drivingLicenceDocument);
-        IssuerSigned issuerSigned = issuerSignedFactory.build(namespaces);
+        IssuerSigned issuerSigned = issuerSignedFactory.build(namespaces, publicKey);
         byte[] cborEncodedMobileDrivingLicence = cborEncoder.encode(issuerSigned);
         return Base64.getUrlEncoder()
                 .withoutPadding()

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cose/BigIntegerToFixedBytes.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cose/BigIntegerToFixedBytes.java
@@ -1,0 +1,67 @@
+package uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose;
+
+import java.math.BigInteger;
+
+public class BigIntegerToFixedBytes {
+
+    private BigIntegerToFixedBytes() {
+        // Can't be instantiated
+    }
+
+    /**
+     * Converts a BigInteger to a fixed-length byte array using truncation/padding approach.
+     *
+     * <p>This method preserves all leading zeros in the BigInteger representation and uses
+     * truncation for oversized values (keeping the least significant bytes). This approach is
+     * required because exact byte lengths are required in COSE keys.
+     *
+     * <p><strong>Handling scenarios:</strong>
+     *
+     * <ul>
+     *   <li><strong>Exact match:</strong> Returns the array as-is
+     *   <li><strong>Too long:</strong> Takes the rightmost bytes (truncates from left)
+     *   <li><strong>Too short:</strong> Pads with leading zeros (big-endian format)
+     * </ul>
+     *
+     * <p><strong>Example:</strong>
+     *
+     * <pre>{@code
+     * // P-256 curve coordinate (32 bytes needed)
+     * BigInteger coord = new BigInteger("AB12", 16);
+     * byte[] result = bigIntegerToFixedBytes(coord, 256);
+     * // Result: [0x00, 0x00, ..., 0xAB, 0x12] (32 bytes total)
+     * }</pre>
+     *
+     * @param value The BigInteger to convert to a byte array
+     * @param curveSizeBits The curve size in bits (will be converted to bytes using (bits + 7) / 8)
+     * @return A byte array of exactly the calculated byte length representing the BigInteger value
+     */
+    public static byte[] bigIntegerToFixedBytes(BigInteger value, int curveSizeBits) {
+        // Calculate the number of bytes needed for this curve size
+        // The (curveSizeBits + 7) / 8 formula rounds up to the next byte boundary
+        int targetBytes = (curveSizeBits + 7) / 8;
+
+        // Create the result array of the exact size needed
+        byte[] result = new byte[targetBytes];
+
+        // Get the raw byte representation from BigInteger
+        byte[] sourceBytes = value.toByteArray();
+
+        if (result.length == sourceBytes.length) {
+            // Match - return the BigInteger bytes
+            return sourceBytes;
+        } else if (sourceBytes.length > result.length) {
+            // Source is too long - truncate by taking the rightmost bytes
+            // This preserves the least significant bytes (big-endian format)
+            System.arraycopy(
+                    sourceBytes, sourceBytes.length - result.length, result, 0, result.length);
+        } else {
+            // Source is too short - pad with leading zeros
+            // Copy source bytes to the right side of the result array
+            System.arraycopy(
+                    sourceBytes, 0, result, result.length - sourceBytes.length, sourceBytes.length);
+            // The left side is automatically filled with zeros
+        }
+        return result;
+    }
+}

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cose/COSEKey.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cose/COSEKey.java
@@ -1,0 +1,17 @@
+package uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Map;
+
+/**
+ * Represents a COSE_Key structure as defined in RFC 8152, used for encoding public keys in Mobile
+ * Driving License (mDL).
+ *
+ * <p>The {@code @JsonValue} annotation is used here to ensure that when this record is serialized,
+ * the map contents are emitted at the top level, rather than being wrapped inside a "parameters"
+ * property.
+ *
+ * <p>See: <a href="https://www.rfc-editor.org/rfc/rfc8152.html#section-7">RFC 8152, Section 7</a>
+ */
+public record COSEKey(@JsonValue Map<Integer, Object> parameters) {}

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cose/COSEKeyFactory.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cose/COSEKeyFactory.java
@@ -1,0 +1,61 @@
+package uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose;
+
+import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose.constants.COSEEllipticCurves;
+import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose.constants.COSEKeyTypes;
+
+import java.math.BigInteger;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose.BigIntegerToFixedBytes.bigIntegerToFixedBytes;
+
+/**
+ * Factory for creating {@link COSEKey} instance from EC public keys.
+ *
+ * <p>This factory encapsulates the logic for converting a Java {@link ECPublicKey} (specifically on
+ * the P-256 curve) into a COSE_Key (CBOR Object Signing and Encryption key) format, as required for
+ * mobile security objects.
+ */
+public class COSEKeyFactory {
+
+    /**
+     * Creates a {@link COSEKey} from the given EC public key.
+     *
+     * <p>This method validates that the provided key uses the P-256 curve, extracts the x and y
+     * coordinates, and encodes them as fixed-length byte arrays to construct the {@link COSEKey}
+     * object.
+     *
+     * @param publicKey the EC public key to convert.
+     * @return The {@link COSEKey} representation of the public key.
+     * @throws IllegalArgumentException If the key does not use the P-256 curve.
+     */
+    public COSEKey fromECPublicKey(ECPublicKey publicKey) {
+        // Validate curve is P-256
+        ECParameterSpec params = publicKey.getParams();
+        int curveSizeBits = params.getCurve().getField().getFieldSize();
+        if (curveSizeBits != 256) {
+            throw new IllegalArgumentException("Invalid key curve - expected P-256");
+        }
+
+        // Extract x and y coordinates
+        ECPoint point = publicKey.getW();
+        BigInteger x = point.getAffineX();
+        BigInteger y = point.getAffineY();
+
+        // Convert BigInteger to fixed-length byte array
+        byte[] xBytes = bigIntegerToFixedBytes(x, curveSizeBits);
+        byte[] yBytes = bigIntegerToFixedBytes(y, curveSizeBits);
+
+        // Build the COSE key map
+        Map<Integer, Object> coseKeyMap = new LinkedHashMap<>();
+        coseKeyMap.put(1, COSEKeyTypes.EC2); // Key type: EC2
+        coseKeyMap.put(-1, COSEEllipticCurves.P256); // Curve: P-256
+        coseKeyMap.put(-2, xBytes); // x-coordinate
+        coseKeyMap.put(-3, yBytes); // y-coordinate
+
+        return new COSEKey(coseKeyMap);
+    }
+}

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cose/constants/COSEEllipticCurves.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cose/constants/COSEEllipticCurves.java
@@ -1,0 +1,8 @@
+package uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose.constants;
+
+public final class COSEEllipticCurves {
+    /** P-256 (-1) */
+    public static final int P256 = -1;
+
+    private COSEEllipticCurves() {}
+}

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cose/constants/COSEKeyTypes.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cose/constants/COSEKeyTypes.java
@@ -1,0 +1,8 @@
+package uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose.constants;
+
+public final class COSEKeyTypes {
+    /** EC2 (2); 2 coordinate elliptic curve key type */
+    public static final int EC2 = 2;
+
+    private COSEKeyTypes() {}
+}

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/DeviceKeyInfo.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/DeviceKeyInfo.java
@@ -1,0 +1,5 @@
+package uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc;
+
+import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose.COSEKey;
+
+public record DeviceKeyInfo(COSEKey deviceKey, KeyAuthorizations keyAuthorizations) {}

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/IssuerSignedFactory.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/IssuerSignedFactory.java
@@ -12,6 +12,7 @@ import uk.gov.di.mobile.wallet.cri.util.ArnUtil;
 
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPublicKey;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -37,9 +38,10 @@ public class IssuerSignedFactory {
         this.documentSigningKey1Arn = documentSigningKey1Arn;
     }
 
-    public IssuerSigned build(Namespaces namespaces)
+    public IssuerSigned build(Namespaces namespaces, ECPublicKey publicKey)
             throws MDLException, SigningException, CertificateException, ObjectStoreException {
-        MobileSecurityObject mobileSecurityObject = mobileSecurityObjectFactory.build(namespaces);
+        MobileSecurityObject mobileSecurityObject =
+                mobileSecurityObjectFactory.build(namespaces, publicKey);
         byte[] mobileSecurityObjectBytes = cborEncoder.encode(mobileSecurityObject);
 
         String certificateId = ArnUtil.extractKeyId(documentSigningKey1Arn);

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/KeyAuthorizations.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/KeyAuthorizations.java
@@ -1,0 +1,5 @@
+package uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc;
+
+import java.util.Set;
+
+public record KeyAuthorizations(Set<String> nameSpaces) {}

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/MobileSecurityObject.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/MobileSecurityObject.java
@@ -3,6 +3,7 @@ package uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc;
 public record MobileSecurityObject(
         String version,
         String digestAlgorithm,
+        DeviceKeyInfo deviceKeyInfo,
         ValueDigests valueDigests,
         String docType,
         ValidityInfo validityInfo) {}

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/MobileSecurityObjectFactory.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/MobileSecurityObjectFactory.java
@@ -1,13 +1,19 @@
 package uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc;
 
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.MDLException;
+import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose.COSEKey;
+import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose.COSEKeyFactory;
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.constants.DocumentTypes;
 
-import java.time.Clock;
-import java.time.Duration;
-import java.time.Instant;
+import java.security.interfaces.ECPublicKey;
+import java.util.Set;
 
-/** Factory class for creating MobileSecurityObject instances. */
+/**
+ * Factory for creating {@link MobileSecurityObject} instances for mobile driver's licenses.
+ *
+ * <p>This factory handles the creation of value digests, validity information, and device key
+ * information required for the MSO.
+ */
 public class MobileSecurityObjectFactory {
 
     /** The version for the {@link MobileSecurityObject}. */
@@ -22,56 +28,67 @@ public class MobileSecurityObjectFactory {
     /** The factory responsible for creating {@link ValueDigests} instances. */
     private final ValueDigestsFactory valueDigestsFactory;
 
-    /** The source of current time for validity information. */
-    private final Clock clock;
+    /** The factory responsible for creating {@link ValidityInfo} instances. */
+    private final ValidityInfoFactory validityInfoFactory;
+
+    /** The factory responsible for creating {@link COSEKeyFactory} instances. */
+    private final COSEKeyFactory coseKeyFactory;
 
     /**
-     * Constructs a new {@link MobileSecurityObjectFactory} with the provided {@link
-     * ValueDigestsFactory}.
+     * Constructs a new {@link MobileSecurityObjectFactory} with the provided factories.
      *
      * @param valueDigestsFactory The factory used to create value digests for the {@link
      *     MobileSecurityObject}.
-     */
-    public MobileSecurityObjectFactory(ValueDigestsFactory valueDigestsFactory) {
-        this(valueDigestsFactory, Clock.systemDefaultZone());
-    }
-
-    /**
-     * Constructs a new {@link MobileSecurityObjectFactory} with the provided {@link
-     * ValueDigestsFactory} and {@link Clock}.
-     *
-     * @param valueDigestsFactory The factory used to create value digests for the {@link
+     * @param validityInfoFactory The factory used to create validity information for the {@link
      *     MobileSecurityObject}.
-     * @param clock The source of current time for validity information.
+     * @param coseKeyFactory The factory used to create the COSE key for the {@link
+     *     MobileSecurityObject}.
      */
-    public MobileSecurityObjectFactory(ValueDigestsFactory valueDigestsFactory, Clock clock) {
+    public MobileSecurityObjectFactory(
+            ValueDigestsFactory valueDigestsFactory,
+            ValidityInfoFactory validityInfoFactory,
+            COSEKeyFactory coseKeyFactory) {
         this.valueDigestsFactory = valueDigestsFactory;
-        this.clock = clock;
+        this.validityInfoFactory = validityInfoFactory;
+        this.coseKeyFactory = coseKeyFactory;
     }
 
     /**
-     * Builds a {@link MobileSecurityObject} instance from the provided namespaces.
+     * Builds a {@link MobileSecurityObject} instance from the provided namespaces and public key.
      *
-     * <p>This method generates the value digests for each namespace and constructs the {@link
-     * MobileSecurityObject}.
+     * <p>This method creates a mobile security object by:
+     *
+     * <ul>
+     *   <li>Generating value digests for the provided namespaces
+     *   <li>Creating validity information with a one-year validity period
+     *   <li>Converting the EC public key to COSE key format
+     *   <li>Setting up key authorizations for all provided namespaces
+     * </ul>
+     *
+     * <p>The validity period is determined by the configured {@link ValidityInfoFactory}. The
+     * created MSO will authorize access to all namespaces provided in the input.
      *
      * @param nameSpaces A map where the key is the namespace string and the value is a list of
      *     {@link IssuerSignedItem} objects belonging to that namespace. This map provides the data
      *     used to generate the value digests for the {@link MobileSecurityObject}.
+     * @param publicKey The EC public key for device authentication. Must use the P-256 curve.
      * @return The constructed {@link MobileSecurityObject} instance.
      * @throws MDLException If an error occurs during the creation of the {@link ValueDigests}.
+     * @throws IllegalArgumentException If the public key does not use the P-256 curve.
      */
-    public MobileSecurityObject build(Namespaces nameSpaces) throws MDLException {
+    public MobileSecurityObject build(Namespaces nameSpaces, ECPublicKey publicKey)
+            throws MDLException {
         ValueDigests valueDigests = valueDigestsFactory.createFromNamespaces(nameSpaces);
+        ValidityInfo validityInfo = validityInfoFactory.build();
+        COSEKey coseKey = coseKeyFactory.fromECPublicKey(publicKey);
 
-        Instant currentTimestamp = clock.instant();
-        Instant validUntil = currentTimestamp.plus(Duration.ofDays(365));
-
-        var validityInfo = new ValidityInfo(currentTimestamp, currentTimestamp, validUntil);
+        Set<String> authorizedNameSpaces = nameSpaces.asMap().keySet();
+        KeyAuthorizations keyAuthorizations = new KeyAuthorizations(authorizedNameSpaces);
 
         return new MobileSecurityObject(
                 MSO_VERSION,
                 valueDigestsFactory.getDigestAlgorithm(),
+                new DeviceKeyInfo(coseKey, keyAuthorizations),
                 valueDigests,
                 DOC_TYPE,
                 validityInfo);

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/ValidityInfoFactory.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/ValidityInfoFactory.java
@@ -1,0 +1,46 @@
+package uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Factory for creating {@link ValidityInfo} objects.
+ *
+ * <p>This factory encapsulates the logic for creating validity information used in mobile security
+ * objects.
+ */
+public class ValidityInfoFactory {
+
+    /** The source of current time for validity information. */
+    private final Clock clock;
+
+    /** Constructs a new {@link ValidityInfoFactory}. */
+    public ValidityInfoFactory() {
+        this.clock = Clock.systemDefaultZone();
+    }
+
+    /**
+     * Constructs a new {@link ValidityInfoFactory} with the specified clock.
+     *
+     * @param clock The source of current time for validity information.
+     */
+    public ValidityInfoFactory(Clock clock) {
+        this.clock = clock;
+    }
+
+    /**
+     * Creates a {@link ValidityInfo} object with a one-year validity period.
+     *
+     * <p>The validity period starts from the current time and extends for 365 days. Both the signed
+     * and valid from timestamps are set to the current time.
+     *
+     * @return A {@link ValidityInfo} object with current time as signed/valid from and current time
+     *     plus 365 days as valid until.
+     */
+    public ValidityInfo build() {
+        Instant currentTimestamp = clock.instant();
+        Instant validUntil = currentTimestamp.plus(Duration.ofDays(365));
+        return new ValidityInfo(currentTimestamp, currentTimestamp, validUntil);
+    }
+}

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialServiceTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialServiceTest.java
@@ -22,6 +22,7 @@ import uk.gov.di.mobile.wallet.cri.services.data_storage.DataStoreException;
 import uk.gov.di.mobile.wallet.cri.services.data_storage.DynamoDbService;
 import uk.gov.di.mobile.wallet.cri.services.signing.SigningException;
 
+import java.security.interfaces.ECPublicKey;
 import java.time.Instant;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -51,6 +52,7 @@ class CredentialServiceTest {
     @Mock private MobileDrivingLicenceService mockMobileDrivingLicenceService;
 
     @Mock private Logger mockLogger;
+    @Mock private ECPublicKey mockEcPublicKey;
 
     private final DynamoDbService mockDynamoDbService = mock(DynamoDbService.class);
     private final AccessTokenService mockAccessTokenService = mock(AccessTokenService.class);
@@ -294,7 +296,7 @@ class CredentialServiceTest {
         credentialService.getCredential(mockAccessToken, mockProofJwt);
 
         verify(mockMobileDrivingLicenceService, times(1))
-                .createMobileDrivingLicence(any(DrivingLicenceDocument.class));
+                .createMobileDrivingLicence(any(DrivingLicenceDocument.class), eq(mockEcPublicKey));
         verify(mockDynamoDbService).saveStoredCredential(any(StoredCredential.class));
     }
 
@@ -364,6 +366,7 @@ class CredentialServiceTest {
     }
 
     private ProofJwtService.ProofJwtData getMockProofJwtData(String nonce) {
-        return new ProofJwtService.ProofJwtData(CredentialServiceTest.DID_KEY, nonce);
+        return new ProofJwtService.ProofJwtData(
+                CredentialServiceTest.DID_KEY, nonce, mockEcPublicKey);
     }
 }

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/ProofJwtServiceTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/ProofJwtServiceTest.java
@@ -46,7 +46,7 @@ class ProofJwtServiceTest {
                         ProofJwtValidationException.class,
                         () -> proofJwtService.verifyProofJwt(mockProof));
         assertEquals(
-                "JWT alg header claim [RS256] does not match client config alg [ES256]",
+                "JWT alg header claim [RS256] does not match expected algorithm [ES256]",
                 exception.getMessage());
     }
 
@@ -134,7 +134,7 @@ class ProofJwtServiceTest {
 
         assertThat(
                 exception.getMessage(),
-                containsString("Error verifying signature: did:key must be base58 encoded"));
+                containsString("Error getting public key from did:key [did:key:notAValidDidKey]"));
     }
 
     @Test
@@ -149,7 +149,9 @@ class ProofJwtServiceTest {
                         ProofJwtValidationException.class,
                         () -> proofJwtService.verifyProofJwt(mockProof));
 
-        assertEquals("JWT type header claim is invalid", exception.getMessage());
+        assertEquals(
+                "JWT type header claim [invalid-proof+jwt] does not match expected type [openid4vci-proof+jwt]",
+                exception.getMessage());
     }
 
     @Test

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cbor/MobileSecurityObjectSerializerTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cbor/MobileSecurityObjectSerializerTest.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose.COSEKey;
+import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.DeviceKeyInfo;
+import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.KeyAuthorizations;
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.MobileSecurityObject;
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.ValidityInfo;
 import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc.ValueDigests;
@@ -17,6 +20,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -39,6 +43,15 @@ class MobileSecurityObjectSerializerTest {
 
     @Test
     void Should_SerializeMobileSecurityObjectWithCBORGenerator() throws IOException {
+        // Arrange: Prepare DeviceKeyInfo
+        Map<Integer, Object> parameterMap = new HashMap<>();
+        parameterMap.put(1, "testParameterValue");
+        parameterMap.put(-1, 2);
+        COSEKey coseKey = new COSEKey(parameterMap);
+        KeyAuthorizations keyAuthorizations =
+                new KeyAuthorizations(Set.of("testNamespace1", "testNamespace2"));
+        DeviceKeyInfo deviceKeyInfo = new DeviceKeyInfo(coseKey, keyAuthorizations);
+
         // Arrange: Prepare ValueDigests
         Map<Integer, byte[]> digestMap = new HashMap<>();
         digestMap.put(1, new byte[] {0x01, 0x02, 0x03});
@@ -56,7 +69,12 @@ class MobileSecurityObjectSerializerTest {
         // Arrange: Create the test object
         MobileSecurityObject testObject =
                 new MobileSecurityObject(
-                        "1.0", "SHA-256", valueDigests, "org.iso.18013.5.1.mDL", validityInfo);
+                        "1.0",
+                        "SHA-256",
+                        deviceKeyInfo,
+                        valueDigests,
+                        "org.iso.18013.5.1.mDL",
+                        validityInfo);
 
         // Act: Serialize the object
         serializer.serialize(testObject, cborGenerator, serializerProvider);

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cose/BigIntegerToFixedBytesTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cose/BigIntegerToFixedBytesTest.java
@@ -1,0 +1,67 @@
+package uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BigIntegerToFixedBytesTest {
+
+    /** Test that a value whose byte array matches the target length is returned as-is. */
+    @Test
+    void Should_HandleExactSizeMatch() {
+        BigInteger value = new BigInteger("ABCD", 16); // [0xAB, 0xCD]
+        int curveSizeBits = 16; // 2 bytes
+
+        byte[] result = BigIntegerToFixedBytes.bigIntegerToFixedBytes(value, curveSizeBits);
+
+        assertEquals(2, result.length);
+        assertArrayEquals(new byte[] {(byte) 0xAB, (byte) 0xCD}, result);
+    }
+
+    /** Test that a value shorter than the target length is padded with leading zeros. */
+    @Test
+    void Should_PadWithLeadingZeros_When_ValueIsTooShort() {
+        BigInteger value = new BigInteger("AB", 16); // [0xAB]
+        int curveSizeBits = 32; // 4 bytes
+
+        byte[] result = BigIntegerToFixedBytes.bigIntegerToFixedBytes(value, curveSizeBits);
+
+        assertEquals(4, result.length);
+        assertArrayEquals(new byte[] {0x00, 0x00, 0x00, (byte) 0xAB}, result);
+    }
+
+    /**
+     * Test that a value longer than the target length is truncated from the left (most significant
+     * bytes).
+     */
+    @Test
+    void Should_TruncateFromLeft_When_ValueIsTooLarge() {
+        BigInteger value = new BigInteger("ABCDEF12", 16); // [0xAB, 0xCD, 0xEF, 0x12]
+        int curveSizeBits = 16; // 2 bytes
+
+        byte[] result = BigIntegerToFixedBytes.bigIntegerToFixedBytes(value, curveSizeBits);
+
+        assertEquals(2, result.length);
+        assertArrayEquals(new byte[] {(byte) 0xEF, 0x12}, result);
+    }
+
+    /** Test that the method correctly pads to a typical 256-bit curve length. */
+    @Test
+    void Should_HandleP256CurveSize() {
+        BigInteger value = new BigInteger("1234", 16); // [0x12, 0x34]
+        int curveSizeBits = 256; // 32 bytes
+
+        byte[] result = BigIntegerToFixedBytes.bigIntegerToFixedBytes(value, curveSizeBits);
+
+        assertEquals(32, result.length);
+        // Should be padded with 30 leading zeros followed by 0x12, 0x34
+        for (int i = 0; i < 30; i++) {
+            assertEquals(0, result[i]);
+        }
+        assertEquals(0x12, result[30] & 0xFF);
+        assertEquals(0x34, result[31] & 0xFF);
+    }
+}

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cose/COSEKeyFactoryTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/cose/COSEKeyFactoryTest.java
@@ -1,0 +1,94 @@
+package uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose.constants.COSEEllipticCurves;
+import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose.constants.COSEKeyTypes;
+
+import java.math.BigInteger;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECFieldFp;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.EllipticCurve;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class COSEKeyFactoryTest {
+
+    @Mock private ECPublicKey mockEcPublicKey;
+    @Mock private ECParameterSpec mockParams;
+    @Mock private EllipticCurve mockCurve;
+    @Mock private ECFieldFp mockField;
+    @Mock private ECPoint mockPoint;
+
+    private COSEKeyFactory coseKeyFactory;
+
+    @BeforeEach
+    void setUp() {
+        coseKeyFactory = new COSEKeyFactory();
+    }
+
+    @Test
+    void Should_ConvertP256KeyToCOSEKey() {
+        // Arrange: Mock EC key
+        when(mockEcPublicKey.getParams()).thenReturn(mockParams);
+        when(mockParams.getCurve()).thenReturn(mockCurve);
+        when(mockCurve.getField()).thenReturn(mockField);
+        when(mockField.getFieldSize()).thenReturn(256); // P-256 curve
+        when(mockEcPublicKey.getW()).thenReturn(mockPoint);
+        final BigInteger x = new BigInteger("123456789");
+        final BigInteger y = new BigInteger("987654321");
+        when(mockPoint.getAffineX()).thenReturn(x);
+        when(mockPoint.getAffineY()).thenReturn(y);
+
+        // Arrange: Mock static method for converting BigInteger to fixed-length bytes
+        final byte[] xBytes = new byte[] {1, 2, 3, 4};
+        final byte[] yBytes = new byte[] {5, 6, 7, 8};
+        try (MockedStatic<BigIntegerToFixedBytes> mocked =
+                mockStatic(BigIntegerToFixedBytes.class, CALLS_REAL_METHODS)) {
+            mocked.when(() -> BigIntegerToFixedBytes.bigIntegerToFixedBytes(x, 256))
+                    .thenReturn(xBytes);
+            mocked.when(() -> BigIntegerToFixedBytes.bigIntegerToFixedBytes(y, 256))
+                    .thenReturn(yBytes);
+
+            // Act: Convert EC key to COSEKey
+            COSEKey coseKey = coseKeyFactory.fromECPublicKey(mockEcPublicKey);
+
+            // Assert: COSEKey parameters match expectations
+            Map<Integer, Object> parameters = coseKey.parameters();
+            assertEquals(4, parameters.size(), "COSEKey map should have 4 items");
+            assertEquals(COSEKeyTypes.EC2, parameters.get(1), "Key type should be EC2");
+            assertEquals(COSEEllipticCurves.P256, parameters.get(-1), "Curve should be P-256");
+            assertArrayEquals(xBytes, (byte[]) parameters.get(-2), "x coordinate bytes match");
+            assertArrayEquals(yBytes, (byte[]) parameters.get(-3), "y coordinate bytes match");
+        }
+    }
+
+    @Test
+    void Should_ThrowIllegalArgumentException_When_NonP256Curve() {
+        // Arrange: Mock EC key
+        when(mockEcPublicKey.getParams()).thenReturn(mockParams);
+        when(mockParams.getCurve()).thenReturn(mockCurve);
+        when(mockCurve.getField()).thenReturn(mockField);
+        when(mockField.getFieldSize()).thenReturn(384); // P-384 curve
+
+        // Act & Assert
+        IllegalArgumentException exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> coseKeyFactory.fromECPublicKey(mockEcPublicKey));
+        assertEquals("Invalid key curve - expected P-256", exception.getMessage());
+    }
+}

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/MobileSecurityObjectFactoryTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/MobileSecurityObjectFactoryTest.java
@@ -4,13 +4,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose.COSEKey;
+import uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.cose.COSEKeyFactory;
 
+import java.security.interfaces.ECPublicKey;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
@@ -20,33 +25,59 @@ import static org.mockito.Mockito.when;
 class MobileSecurityObjectFactoryTest {
 
     @Mock private ValueDigestsFactory mockValueDigestsFactory;
+    @Mock private ValidityInfoFactory mockValidityInfoFactory;
+    @Mock private COSEKeyFactory mockCoseKeyFactory;
+    @Mock private ECPublicKey mockEcPublicKey;
 
     @Test
     void Should_CreateMobileSecurityObject() {
+        // Arrange: Prepare IssuerSignedItem and Namespaces
         IssuerSignedItem issuerSignedItem =
                 new IssuerSignedItem(5, new byte[] {1, 2, 3}, "ID", "Test");
-        Namespaces namespaces = new Namespaces(Map.of("Test", List.of(issuerSignedItem)));
+        Namespaces namespaces = new Namespaces(Map.of("testNamespace1", List.of(issuerSignedItem)));
+
+        // Arrange: Prepare ValueDigests
         ValueDigests valueDigests = new ValueDigests(Map.of("Test", Map.of(5, new byte[] {1})));
         when(mockValueDigestsFactory.createFromNamespaces(namespaces)).thenReturn(valueDigests);
         when(mockValueDigestsFactory.getDigestAlgorithm()).thenReturn("SHA-256");
+
+        // Arrange: Prepare ValidityInfo
         Clock clock = Clock.fixed(Instant.ofEpochSecond(1750677223), ZoneId.systemDefault());
+        Instant now = clock.instant();
+        ValidityInfo validityInfo = new ValidityInfo(now, now, now.plus(Duration.ofDays(365)));
+        when(mockValidityInfoFactory.build()).thenReturn(validityInfo);
 
-        MobileSecurityObject result =
-                new MobileSecurityObjectFactory(mockValueDigestsFactory, clock).build(namespaces);
+        // Arrange: Prepare COSEKey
+        Map<Integer, Object> coseKeyParams = new HashMap<>();
+        coseKeyParams.put(1, "testParameterValue");
+        coseKeyParams.put(-1, 2);
+        COSEKey coseKey = new COSEKey(coseKeyParams);
+        when(mockCoseKeyFactory.fromECPublicKey(mockEcPublicKey)).thenReturn(coseKey);
 
-        ValidityInfo expectedValidityInfo =
-                new ValidityInfo(
-                        clock.instant(),
-                        clock.instant(),
-                        clock.instant().plus(Duration.ofDays(365)));
+        // Arrange: Build expected DeviceKeyInfo and MobileSecurityObject
+        Set<String> authorizedNamespaces = Set.of("testNamespace1");
+        KeyAuthorizations keyAuthorizations = new KeyAuthorizations(authorizedNamespaces);
+        DeviceKeyInfo deviceKeyInfo = new DeviceKeyInfo(coseKey, keyAuthorizations);
         MobileSecurityObject expectedMso =
                 new MobileSecurityObject(
                         "1.0",
                         "SHA-256",
+                        deviceKeyInfo,
                         valueDigests,
                         "org.iso.18013.5.1.mDL",
-                        expectedValidityInfo);
-        assertEquals(expectedMso, result);
+                        validityInfo);
+
+        // Act
+        MobileSecurityObjectFactory factory =
+                new MobileSecurityObjectFactory(
+                        mockValueDigestsFactory, mockValidityInfoFactory, mockCoseKeyFactory);
+        MobileSecurityObject result = factory.build(namespaces, mockEcPublicKey);
+
+        // Assert
+        assertEquals(expectedMso, result, "MobileSecurityObject should be constructed as expected");
         verify(mockValueDigestsFactory).createFromNamespaces(namespaces);
+        verify(mockValueDigestsFactory).getDigestAlgorithm();
+        verify(mockValidityInfoFactory).build();
+        verify(mockCoseKeyFactory).fromECPublicKey(mockEcPublicKey);
     }
 }

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/ValidityInfoFactoryTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/mobile_driving_licence/mdoc/ValidityInfoFactoryTest.java
@@ -1,0 +1,54 @@
+package uk.gov.di.mobile.wallet.cri.credential.mobile_driving_licence.mdoc;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ValidityInfoFactoryTest {
+    private static final Instant FIXED_INSTANT = Instant.parse("2024-01-15T10:30:00Z");
+
+    @Test
+    void Should_CreateValidityInfoWithProvidedClock() {
+        Clock fixedClock = Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC);
+
+        ValidityInfoFactory factory = new ValidityInfoFactory(fixedClock);
+        ValidityInfo validityInfo = factory.build();
+
+        assertEquals(FIXED_INSTANT, validityInfo.signed(), "signed should be current time");
+        assertEquals(FIXED_INSTANT, validityInfo.validFrom(), "validFrom should be current time");
+        assertEquals(
+                FIXED_INSTANT.plus(Duration.ofDays(365)),
+                validityInfo.validTo(),
+                "validTo should be 365 days later");
+    }
+
+    @Test
+    void Should_UseSystemDefaultZoneClock_When_NoClockPassedToConstructor() {
+        Instant beforeCreation = Instant.now();
+
+        ValidityInfoFactory factory = new ValidityInfoFactory();
+        ValidityInfo validityInfo = factory.build();
+
+        assertNotNull(validityInfo);
+        Instant afterCreation = Instant.now();
+        // Verify timestamps are within reasonable bounds
+        assertTrue(
+                validityInfo.signed().isAfter(beforeCreation)
+                        || validityInfo.signed().equals(beforeCreation));
+        assertTrue(
+                validityInfo.validFrom().isBefore(afterCreation)
+                        || validityInfo.validFrom().equals(afterCreation));
+        // Verify the duration is exactly 365 days
+        Duration actualDuration =
+                Duration.between(validityInfo.validFrom(), validityInfo.validTo());
+
+        assertEquals(Duration.ofDays(365), actualDuration);
+    }
+}


### PR DESCRIPTION
Replaces https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/pull/281 and https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/pull/297.

## Proposed changes
### What changed

**Add DeviceKeyInfo to MSO:**
- Add decoded did:key as `ECPublicKey` to `ProofJwtData` so that it can be passed to the `MobileDrivingLicenceService` where it's needed
- Add new factory `COSEKeyFactory` to build the `COSEKey` object from the `ECPublicKey`
- Add `BigIntegerToFixedBytes` helper to convert the public key x and y coordinates from `BigInteger` to fixed-length byte array
- Build `KeyAuthorizations` array from namespaces 
- Build `DeviceKeyInfo` and add it to `MobileSecurityObject`
- Extract logic to build `ValidityInfo` from `MobileSecurityObjectFactory` into a new factory: `ValidityInfoFactory`

### Why did it change
- To add the `DeviceKeyInfo` to the `MobileSecurityObject`

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-13389](https://govukverify.atlassian.net/browse/DCMAW-13389)

## Testing
Deployed to and tested in the development environment. 

<img width="1432" height="836" alt="image" src="https://github.com/user-attachments/assets/d49f04f7-0ab0-4cf6-aa2f-484bbd8afce8" />

## Checklist
- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->

[DCMAW-13389]: https://govukverify.atlassian.net/browse/DCMAW-13389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ