### PR TITLE
build: update the certificate authority ARN in the CRI SAM template

### DIFF
--- a/example-credential-issuer/deploy/template.yaml
+++ b/example-credential-issuer/deploy/template.yaml
@@ -60,7 +60,7 @@ Mappings:
       BackImageRepository: arn:aws:ecr:eu-west-2:671524980203:repository/wallet-cred-issuer-be-ecr-containerrepository-ta87rf6hloli
       CertificatesBucketName: "wallet-dsc-issuer-671524980203-certificates"
       DocumentSigningKey1Arn: arn:aws:kms:eu-west-2:671524980203:key/72b0ed1b-9fa6-43ae-ba8f-14693868ce72
-      CertificateAuthorityArn: arn:aws:acm-pca:eu-west-2:671524980203:certificate-authority/1c589b25-0433-45e0-b7d9-911fe33a9c1a
+      CertificateAuthorityArn: arn:aws:acm-pca:eu-west-2:671524980203:certificate-authority/dc8de818-634f-4d96-b3ba-fb865cd3776f
     build:
       SelfUrl: "example-credential-issuer.mobile.build.account.gov.uk"
       CredentialStoreUrl: "stub-credential-issuer.mobile.build.account.gov.uk"
@@ -69,7 +69,7 @@ Mappings:
       BackImageRepository: arn:aws:ecr:eu-west-2:497065468681:repository/wallet-cred-issuer-be-ecr-containerrepository-ikbt4gtnl9ew
       CertificatesBucketName: "wallet-dsc-issuer-497065468681-certificates"
       DocumentSigningKey1Arn: arn:aws:kms:eu-west-2:497065468681:key/125a9328-f653-4f8a-bf0b-ad53acbfdf78
-      CertificateAuthorityArn: arn:aws:acm-pca:eu-west-2:497065468681:certificate-authority/80334954-bf3b-4e15-bbeb-ce801c4e36fa
+      CertificateAuthorityArn: arn:aws:acm-pca:eu-west-2:497065468681:certificate-authority/f030bd98-ec3d-4ce9-8adf-4106a7028731
     staging:
       SelfUrl: "example-credential-issuer.mobile.staging.account.gov.uk"
       CredentialStoreUrl: "stub-credential-issuer.mobile.staging.account.gov.uk"
@@ -78,7 +78,7 @@ Mappings:
       BackImageRepository: arn:aws:ecr:eu-west-2:497065468681:repository/wallet-cred-issuer-be-ecr-containerrepository-ikbt4gtnl9ew
       CertificatesBucketName: "wallet-dsc-issuer-497065468681-certificates"
       DocumentSigningKey1Arn: arn:aws:kms:eu-west-2:497065468681:key/125a9328-f653-4f8a-bf0b-ad53acbfdf78
-      CertificateAuthorityArn: arn:aws:acm-pca:eu-west-2:497065468681:certificate-authority/80334954-bf3b-4e15-bbeb-ce801c4e36fa
+      CertificateAuthorityArn: arn:aws:acm-pca:eu-west-2:497065468681:certificate-authority/f030bd98-ec3d-4ce9-8adf-4106a7028731
   ElasticLoadBalancerAccountIds:
     eu-west-2:
       AccountId: 652711504416


### PR DESCRIPTION
## Proposed changes
### What changed
- Update the certificate authority ARN in the example credential issuer SAM template.

Private CA ARN in development:

<img width="1633" height="344" alt="image" src="https://github.com/user-attachments/assets/c5ab9abe-37ab-43bd-a103-90adc8e18436" />

Private CA ARN in build:

<img width="1633" height="344" alt="image" src="https://github.com/user-attachments/assets/aabcc2c4-f147-490a-8199-f69170b06b84" />


### Why did it change
- The certificate authority country code had to be updated from "UK" to "GB" in the development and build environments. This changed caused the certificate authority to be deleted and a new one created with a new ARN.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-15230](https://govukverify.atlassian.net/browse/DCMAW-15230)

## Testing
Tested in the development environment. 

Example CRI `/iacas` endpoint:
<img width="883" height="494" alt="image" src="https://github.com/user-attachments/assets/5cc35940-fd6b-488d-b452-8a1712983e5b" />


## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
https://github.com/govuk-one-login/mobile-platform-infra/pull/787

[DCMAW-15230]: https://govukverify.atlassian.net/browse/DCMAW-15230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ