### PR TITLE
build: seed MSO signing key and update static certificate

### DIFF
--- a/example-credential-issuer/localstack/provision.sh
+++ b/example-credential-issuer/localstack/provision.sh
@@ -23,46 +23,59 @@ aws --endpoint-url=http://localhost:4566 dynamodb create-table \
 aws --endpoint-url=http://localhost:4566 dynamodb update-time-to-live --table-name $CREDENTIAL_TABLE_NAME \
                       --time-to-live-specification Enabled=true,AttributeName=timeToLive
 
+# Create signing key pair - signs JWTs and JWT-based credentials
 aws --endpoint-url=http://localhost:4566 kms create-key \
     --region eu-west-2 \
     --key-usage SIGN_VERIFY \
     --key-spec ECC_NIST_P256 \
-    --tags '[{"TagKey":"_custom_id_","TagValue":"ff275b92-0def-4dfc-b0f6-87c96b26c6c7"}]' # signing key
+    --tags '[{"TagKey":"_custom_id_","TagValue":"ff275b92-0def-4dfc-b0f6-87c96b26c6c7"}]'
 
 aws --endpoint-url=http://localhost:4566 kms create-alias \
     --region eu-west-2 \
     --alias-name alias/localSigningKeyAlias \
     --target-key-id ff275b92-0def-4dfc-b0f6-87c96b26c6c7
 
+# Create document signing certificate key pair with custom key material - signs mdoc credentials
 aws --endpoint-url=http://localhost:4566 kms create-key \
     --region eu-west-2 \
     --key-usage SIGN_VERIFY \
     --key-spec ECC_NIST_P256 \
-    --tags '[{"TagKey":"_custom_id_","TagValue":"1291b7bc-3d2c-47f0-a52a-cb6cb0fba6b4"}]' # document signing key
+    --tags '[{"TagKey":"_custom_key_material_","TagValue":"MHcCAQEEIKexbdPE2TDYzOuasfwN4QWNqHF1wNsV30ERMPPaRYnWoAoGCCqGSM49AwEHoUQDQgAE+NKi4QpYV/avqTFFoldRIYEZaRgKF/qv+xJsek63Eh2cKn922zlJHj2KglzSlLm439BfFYGDYVet6W7pkvIYfg=="},{"TagKey":"_custom_id_","TagValue":"1291b7bc-3d2c-47f0-a52a-cb6cb0fba6b4"}]'
 
 aws --endpoint-url=http://localhost:4566 s3api create-bucket --bucket certificates --create-bucket-configuration LocationConstraint=eu-west-2 --region eu-west-2
 
-cat <<EOF > certificate.pem
+cat <<EOF > root-certificate.pem
 -----BEGIN CERTIFICATE-----
-MIICzzCCAnWgAwIBAgIUFBD7/XkDw4D/UTy7/pf1Q7c43/kwCgYIKoZIzj0EAwIw
-gbwxCzAJBgNVBAYTAlVLMQ8wDQYDVQQIDAZMb25kb24xNDAyBgNVBAoMK21ETCBF
-eGFtcGxlIElBQ0EgUm9vdCAtIERFTE9DQUwgZW52aXJvbm1lbnQxMjAwBgNVBAsM
-KW1ETCBFeGFtcGxlIElBQ0EgUm9vdCAtIExPQ0FMIGVudmlyb25tZW50MTIwMAYD
-VQQDDCltREwgRXhhbXBsZSBJQUNBIFJvb3QgLSBMT0NBTCBlbnZpcm9ubWVudDAe
-Fw0yNTA2MTkxMTA4NTFaFw0zNTA2MTcxMTA4NTFaMIG8MQswCQYDVQQGEwJVSzEP
-MA0GA1UECAwGTG9uZG9uMTQwMgYDVQQKDCttREwgRXhhbXBsZSBJQUNBIFJvb3Qg
-LSBERUxPQ0FMIGVudmlyb25tZW50MTIwMAYDVQQLDCltREwgRXhhbXBsZSBJQUNB
-IFJvb3QgLSBMT0NBTCBlbnZpcm9ubWVudDEyMDAGA1UEAwwpbURMIEV4YW1wbGUg
-SUFDQSBSb290IC0gTE9DQUwgZW52aXJvbm1lbnQwWTATBgcqhkjOPQIBBggqhkjO
-PQMBBwNCAATK8ZrETZ7FQXw3+xj7fLV2yv1vFLOlZE0r2MQ0ysBOa/uZ7dUlOCvR
-OTt5fpDR9e+Hdq0h9trZwwBY2HODAWVbo1MwUTAdBgNVHQ4EFgQUnelQVCApK3NI
-xVeQ3X+zUsogQxgwHwYDVR0jBBgwFoAUnelQVCApK3NIxVeQ3X+zUsogQxgwDwYD
-VR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiBwnpi6jeCSLxZgFeFLSN+z
-aG3zj9t6QcGFklY521tMtQIhAOF65mV0uski5+50FtKkJcVnS/1EDGrgor5bFeZD
-vdAI
+MIIB1zCCAX2gAwIBAgIUIatAsTQsYXy6Wrb1Cdp8tJ3RLC0wCgYIKoZIzj0EAwIw
+QTELMAkGA1UEBhMCR0IxMjAwBgNVBAMMKW1ETCBFeGFtcGxlIElBQ0EgUm9vdCAt
+IExPQ0FMIGVudmlyb25tZW50MB4XDTI1MDkwMjEwMjQyNVoXDTI4MDYyMjEwMjQy
+NVowQTELMAkGA1UEBhMCR0IxMjAwBgNVBAMMKW1ETCBFeGFtcGxlIElBQ0EgUm9v
+dCAtIExPQ0FMIGVudmlyb25tZW50MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE
+mBxJk2MqFKn7c4MSEwlA8EUbMMxyU8DnPXwERUs4VjBF7534WDQQLCZBxvaYn73M
+35NYkWiXO8oiRmWG9AzDn6NTMFEwHQYDVR0OBBYEFPY4eri7CuGrxh14YMTQe1qn
+BVjoMB8GA1UdIwQYMBaAFPY4eri7CuGrxh14YMTQe1qnBVjoMA8GA1UdEwEB/wQF
+MAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIgPJmIjY1hoYRHjBMgLeV0x+wWietEyBfx
+zyaulhhqnewCIQCmJ0kwBidqVzCOIx5H8CaEHUnTA/ULJGC2DDFzT7s54A==
 -----END CERTIFICATE-----
 EOF
 
-aws --endpoint-url=http://localhost:4566 s3 cp certificate.pem s3://certificates/6bb42872-f4ed-4d55-a937-b8ffb8760de4/ --region eu-west-2 # root certificate
+# Upload root certificate to S3
+aws --endpoint-url=http://localhost:4566 s3 cp root-certificate.pem s3://certificates/6bb42872-f4ed-4d55-a937-b8ffb8760de4/certificate.pem --region eu-west-2
 
-aws --endpoint-url=http://localhost:4566 s3 cp certificate.pem s3://certificates/1291b7bc-3d2c-47f0-a52a-cb6cb0fba6b4/ --region eu-west-2 # document signing certificate
+cat <<EOF > document-signing-certificate.pem
+-----BEGIN CERTIFICATE-----
+MIIBtzCCAV2gAwIBAgIUZpfeB6WGkUsUk13SiJX8i6vG1IAwCgYIKoZIzj0EAwIw
+QTELMAkGA1UEBhMCR0IxMjAwBgNVBAMMKW1ETCBFeGFtcGxlIElBQ0EgUm9vdCAt
+IExPQ0FMIGVudmlyb25tZW50MB4XDTI1MDkwMjEwMzMzMloXDTI2MDkwMjEwMzMz
+MlowMjELMAkGA1UEBhMCR0IxIzAhBgNVBAMMGkV4YW1wbGUgSXNzdWVyIERTQyAo
+TE9DQUwpMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+NKi4QpYV/avqTFFoldR
+IYEZaRgKF/qv+xJsek63Eh2cKn922zlJHj2KglzSlLm439BfFYGDYVet6W7pkvIY
+fqNCMEAwHQYDVR0OBBYEFFBBWigj2hXjuJNidBxTFPvGxzOLMB8GA1UdIwQYMBaA
+FPY4eri7CuGrxh14YMTQe1qnBVjoMAoGCCqGSM49BAMCA0gAMEUCIQCm99llHZfq
+nPUS1X4/UZfbJ4HlbU33EaTqS/Y4vrOPVQIgLcG3k0jJQIxapcCUF7r/4rVUju0z
+FmibH8pIONDZjSI=
+-----END CERTIFICATE-----
+EOF
+
+# Upload document signing certificate to S3
+aws --endpoint-url=http://localhost:4566 s3 cp document-signing-certificate.pem s3://certificates/1291b7bc-3d2c-47f0-a52a-cb6cb0fba6b4/certificate.pem --region eu-west-2

--- a/example-credential-issuer/localstack/provision.sh
+++ b/example-credential-issuer/localstack/provision.sh
@@ -35,7 +35,7 @@ aws --endpoint-url=http://localhost:4566 kms create-alias \
     --alias-name alias/localSigningKeyAlias \
     --target-key-id ff275b92-0def-4dfc-b0f6-87c96b26c6c7
 
-# Create mDoc signing key pair with custom key material - this key material matches that of the document signing certificate below
+# Create mDoc signing key pair with custom key material - this key material matches the key in the document signing certificate below
 aws --endpoint-url=http://localhost:4566 kms create-key \
     --region eu-west-2 \
     --key-usage SIGN_VERIFY \

--- a/example-credential-issuer/localstack/provision.sh
+++ b/example-credential-issuer/localstack/provision.sh
@@ -23,7 +23,7 @@ aws --endpoint-url=http://localhost:4566 dynamodb create-table \
 aws --endpoint-url=http://localhost:4566 dynamodb update-time-to-live --table-name $CREDENTIAL_TABLE_NAME \
                       --time-to-live-specification Enabled=true,AttributeName=timeToLive
 
-# Create signing key pair - signs JWTs and JWT-based credentials
+# Create signing key pair to sign JWTs and JWT-based credentials
 aws --endpoint-url=http://localhost:4566 kms create-key \
     --region eu-west-2 \
     --key-usage SIGN_VERIFY \
@@ -35,7 +35,7 @@ aws --endpoint-url=http://localhost:4566 kms create-alias \
     --alias-name alias/localSigningKeyAlias \
     --target-key-id ff275b92-0def-4dfc-b0f6-87c96b26c6c7
 
-# Create document signing certificate key pair with custom key material - signs mdoc credentials
+# Create mDoc signing key pair with custom key material - this key material matches that of the document signing certificate below
 aws --endpoint-url=http://localhost:4566 kms create-key \
     --region eu-west-2 \
     --key-usage SIGN_VERIFY \
@@ -44,6 +44,7 @@ aws --endpoint-url=http://localhost:4566 kms create-key \
 
 aws --endpoint-url=http://localhost:4566 s3api create-bucket --bucket certificates --create-bucket-configuration LocationConstraint=eu-west-2 --region eu-west-2
 
+# Root certificate.
 cat <<EOF > root-certificate.pem
 -----BEGIN CERTIFICATE-----
 MIIB1zCCAX2gAwIBAgIUIatAsTQsYXy6Wrb1Cdp8tJ3RLC0wCgYIKoZIzj0EAwIw
@@ -62,6 +63,7 @@ EOF
 # Upload root certificate to S3
 aws --endpoint-url=http://localhost:4566 s3 cp root-certificate.pem s3://certificates/6bb42872-f4ed-4d55-a937-b8ffb8760de4/certificate.pem --region eu-west-2
 
+# Document signing certificate containing the public key from the mDoc signing key pair, signed by the root certificate
 cat <<EOF > document-signing-certificate.pem
 -----BEGIN CERTIFICATE-----
 MIIBtzCCAV2gAwIBAgIUZpfeB6WGkUsUk13SiJX8i6vG1IAwCgYIKoZIzj0EAwIw


### PR DESCRIPTION
## Proposed changes
### What changed

In the LocalStack `provision.sh` script:

- Seed the mdoc KMS signing key with custom key material using the `_custom_key_material_` tag during creation.
- Replace the static certificate (previously used as both root and document signing certificates) with two certificates:
  - A root CA x509 certificate.
  - A document signing certificate generated from the same key material used to seed the mdoc signing key and signed by the above root certificate.

### Why did it change
- To enable local testing of the Example CRI mDL issuance flow.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-14951](https://govukverify.atlassian.net/browse/DCMAW-14951)

## Testing
<img width="732" height="793" alt="Screenshot 2025-09-02 at 11 42 03" src="https://github.com/user-attachments/assets/12f52e75-4054-4cbc-8ecf-0fbdfdf6323e" />
<img width="732" height="481" alt="Screenshot 2025-09-02 at 11 42 18" src="https://github.com/user-attachments/assets/09b27ffd-4b5e-4def-b0f7-4b2d80c7f411" />

<img width="1123" height="778" alt="Screenshot 2025-09-02 at 11 38 09" src="https://github.com/user-attachments/assets/382f0a1a-663b-4db9-bc30-f81a1a161e92" />

- "should be valid pre-authorized code" test is failing because the Example CRI pre-authorized code expiration time is different from what the test harness expects.

- "should return valid IACAs" test is failing because the test harness hasn't been fixed to expect the root certificate country code to be "GB" (correct) instead of "UK".


## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-14951]: https://govukverify.atlassian.net/browse/DCMAW-14951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ