### PR TITLE
fix: invalid PEM in IACAs 

### DIFF
--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/iacas/Iaca.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/iacas/Iaca.java
@@ -72,8 +72,7 @@ public record Iaca(
                         SIGNING_ALGORITHM.toString());
         String fingerprint = getCertificateFingerprint(certificate);
 
-        String normalizedPem = normalizePem(certificatePem);
-        return new Iaca(id, active, normalizedPem, certificateData, fingerprint, publicKeyJwk);
+        return new Iaca(id, active, certificatePem, certificateData, fingerprint, publicKeyJwk);
     }
 
     /**
@@ -92,15 +91,5 @@ public record Iaca(
         MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
         messageDigest.update(certificate.getEncoded());
         return HexFormat.of().formatHex(messageDigest.digest());
-    }
-
-    /**
-     * Removes all line breaks from the PEM string to normalize its format.
-     *
-     * @param pem The PEM-encoded certificate string.
-     * @return The normalized PEM string without line breaks.
-     */
-    private static String normalizePem(String pem) {
-        return pem.replaceAll("\\r?\\n", "");
     }
 }

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/iacas/IacaTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/iacas/IacaTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -16,22 +15,16 @@ class IacaTest {
     private static final String TEST_CERTIFICATE_PEM =
             """
             -----BEGIN CERTIFICATE-----
-            MIICzzCCAnWgAwIBAgIUFBD7/XkDw4D/UTy7/pf1Q7c43/kwCgYIKoZIzj0EAwIw
-            gbwxCzAJBgNVBAYTAlVLMQ8wDQYDVQQIDAZMb25kb24xNDAyBgNVBAoMK21ETCBF
-            eGFtcGxlIElBQ0EgUm9vdCAtIERFTE9DQUwgZW52aXJvbm1lbnQxMjAwBgNVBAsM
-            KW1ETCBFeGFtcGxlIElBQ0EgUm9vdCAtIExPQ0FMIGVudmlyb25tZW50MTIwMAYD
-            VQQDDCltREwgRXhhbXBsZSBJQUNBIFJvb3QgLSBMT0NBTCBlbnZpcm9ubWVudDAe
-            Fw0yNTA2MTkxMTA4NTFaFw0zNTA2MTcxMTA4NTFaMIG8MQswCQYDVQQGEwJVSzEP
-            MA0GA1UECAwGTG9uZG9uMTQwMgYDVQQKDCttREwgRXhhbXBsZSBJQUNBIFJvb3Qg
-            LSBERUxPQ0FMIGVudmlyb25tZW50MTIwMAYDVQQLDCltREwgRXhhbXBsZSBJQUNB
-            IFJvb3QgLSBMT0NBTCBlbnZpcm9ubWVudDEyMDAGA1UEAwwpbURMIEV4YW1wbGUg
-            SUFDQSBSb290IC0gTE9DQUwgZW52aXJvbm1lbnQwWTATBgcqhkjOPQIBBggqhkjO
-            PQMBBwNCAATK8ZrETZ7FQXw3+xj7fLV2yv1vFLOlZE0r2MQ0ysBOa/uZ7dUlOCvR
-            OTt5fpDR9e+Hdq0h9trZwwBY2HODAWVbo1MwUTAdBgNVHQ4EFgQUnelQVCApK3NI
-            xVeQ3X+zUsogQxgwHwYDVR0jBBgwFoAUnelQVCApK3NIxVeQ3X+zUsogQxgwDwYD
-            VR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiBwnpi6jeCSLxZgFeFLSN+z
-            aG3zj9t6QcGFklY521tMtQIhAOF65mV0uski5+50FtKkJcVnS/1EDGrgor5bFeZD
-            vdAI
+            MIIB1zCCAX2gAwIBAgIUIatAsTQsYXy6Wrb1Cdp8tJ3RLC0wCgYIKoZIzj0EAwIw
+            QTELMAkGA1UEBhMCR0IxMjAwBgNVBAMMKW1ETCBFeGFtcGxlIElBQ0EgUm9vdCAt
+            IExPQ0FMIGVudmlyb25tZW50MB4XDTI1MDkwMjEwMjQyNVoXDTI4MDYyMjEwMjQy
+            NVowQTELMAkGA1UEBhMCR0IxMjAwBgNVBAMMKW1ETCBFeGFtcGxlIElBQ0EgUm9v
+            dCAtIExPQ0FMIGVudmlyb25tZW50MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE
+            mBxJk2MqFKn7c4MSEwlA8EUbMMxyU8DnPXwERUs4VjBF7534WDQQLCZBxvaYn73M
+            35NYkWiXO8oiRmWG9AzDn6NTMFEwHQYDVR0OBBYEFPY4eri7CuGrxh14YMTQe1qn
+            BVjoMB8GA1UdIwQYMBaAFPY4eri7CuGrxh14YMTQe1qnBVjoMA8GA1UdEwEB/wQF
+            MAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIgPJmIjY1hoYRHjBMgLeV0x+wWietEyBfx
+            zyaulhhqnewCIQCmJ0kwBidqVzCOIx5H8CaEHUnTA/ULJGC2DDFzT7s54A==
             -----END CERTIFICATE-----
             """;
 
@@ -44,13 +37,25 @@ class IacaTest {
 
         assertEquals("83c71bc0-6d39-4908-ac9f-216424e0c5c5", iaca.id());
         assertTrue(iaca.active());
-        assertNotNull(iaca.certificatePem());
-        assertNotNull(iaca.certificateData());
-        assertNotNull(iaca.certificateFingerprint());
-        assertNotNull(iaca.publicKeyJwk());
-        assertFalse(
-                iaca.certificatePem().contains("\n"),
-                "PEM should be normalised (i.e., no line breaks)");
+        assertEquals(TEST_CERTIFICATE_PEM, iaca.certificatePem());
+        assertEquals(
+                new CertificateData(
+                        "2028-06-22T10:24:25.000Z",
+                        "2025-09-02T10:24:25.000Z",
+                        "GB",
+                        "mDL Example IACA Root - LOCAL environment"),
+                iaca.certificateData());
+        assertEquals(
+                "3907132c3fccd8335625580cf3dce8a3498e578a2f06cd8ed33e05d570e402bf",
+                iaca.certificateFingerprint());
+        assertEquals(
+                new PublicKeyJwk(
+                        "EC",
+                        "P-256",
+                        "mBxJk2MqFKn7c4MSEwlA8EUbMMxyU8DnPXwERUs4VjA",
+                        "Re-d-Fg0ECwmQcb2mJ-9zN-TWJFolzvKIkZlhvQMw58",
+                        "ES256"),
+                iaca.publicKeyJwk());
     }
 
     @Test

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/iacas/IacasServiceTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/iacas/IacasServiceTest.java
@@ -20,25 +20,19 @@ class IacasServiceTest {
 
     private static final String TEST_CERTIFICATE_PEM =
             """
-            -----BEGIN CERTIFICATE-----
-            MIICzzCCAnWgAwIBAgIUFBD7/XkDw4D/UTy7/pf1Q7c43/kwCgYIKoZIzj0EAwIw
-            gbwxCzAJBgNVBAYTAlVLMQ8wDQYDVQQIDAZMb25kb24xNDAyBgNVBAoMK21ETCBF
-            eGFtcGxlIElBQ0EgUm9vdCAtIERFTE9DQUwgZW52aXJvbm1lbnQxMjAwBgNVBAsM
-            KW1ETCBFeGFtcGxlIElBQ0EgUm9vdCAtIExPQ0FMIGVudmlyb25tZW50MTIwMAYD
-            VQQDDCltREwgRXhhbXBsZSBJQUNBIFJvb3QgLSBMT0NBTCBlbnZpcm9ubWVudDAe
-            Fw0yNTA2MTkxMTA4NTFaFw0zNTA2MTcxMTA4NTFaMIG8MQswCQYDVQQGEwJVSzEP
-            MA0GA1UECAwGTG9uZG9uMTQwMgYDVQQKDCttREwgRXhhbXBsZSBJQUNBIFJvb3Qg
-            LSBERUxPQ0FMIGVudmlyb25tZW50MTIwMAYDVQQLDCltREwgRXhhbXBsZSBJQUNB
-            IFJvb3QgLSBMT0NBTCBlbnZpcm9ubWVudDEyMDAGA1UEAwwpbURMIEV4YW1wbGUg
-            SUFDQSBSb290IC0gTE9DQUwgZW52aXJvbm1lbnQwWTATBgcqhkjOPQIBBggqhkjO
-            PQMBBwNCAATK8ZrETZ7FQXw3+xj7fLV2yv1vFLOlZE0r2MQ0ysBOa/uZ7dUlOCvR
-            OTt5fpDR9e+Hdq0h9trZwwBY2HODAWVbo1MwUTAdBgNVHQ4EFgQUnelQVCApK3NI
-            xVeQ3X+zUsogQxgwHwYDVR0jBBgwFoAUnelQVCApK3NIxVeQ3X+zUsogQxgwDwYD
-            VR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiBwnpi6jeCSLxZgFeFLSN+z
-            aG3zj9t6QcGFklY521tMtQIhAOF65mV0uski5+50FtKkJcVnS/1EDGrgor5bFeZD
-            vdAI
-            -----END CERTIFICATE-----
-            """;
+              -----BEGIN CERTIFICATE-----
+              MIIB1zCCAX2gAwIBAgIUIatAsTQsYXy6Wrb1Cdp8tJ3RLC0wCgYIKoZIzj0EAwIw
+              QTELMAkGA1UEBhMCR0IxMjAwBgNVBAMMKW1ETCBFeGFtcGxlIElBQ0EgUm9vdCAt
+              IExPQ0FMIGVudmlyb25tZW50MB4XDTI1MDkwMjEwMjQyNVoXDTI4MDYyMjEwMjQy
+              NVowQTELMAkGA1UEBhMCR0IxMjAwBgNVBAMMKW1ETCBFeGFtcGxlIElBQ0EgUm9v
+              dCAtIExPQ0FMIGVudmlyb25tZW50MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE
+              mBxJk2MqFKn7c4MSEwlA8EUbMMxyU8DnPXwERUs4VjBF7534WDQQLCZBxvaYn73M
+              35NYkWiXO8oiRmWG9AzDn6NTMFEwHQYDVR0OBBYEFPY4eri7CuGrxh14YMTQe1qn
+              BVjoMB8GA1UdIwQYMBaAFPY4eri7CuGrxh14YMTQe1qnBVjoMA8GA1UdEwEB/wQF
+              MAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIgPJmIjY1hoYRHjBMgLeV0x+wWietEyBfx
+              zyaulhhqnewCIQCmJ0kwBidqVzCOIx5H8CaEHUnTA/ULJGC2DDFzT7s54A==
+              -----END CERTIFICATE-----
+              """;
     private static final String TEST_CERTIFICATE_AUTHORITY_ARN =
             "arn:aws:acm-pca:region:account:certificate-authority/1234abcd-12ab-34cd-56ef-1234567890ab";
     private static final String TEST_CERTIFICATE_AUTHORITY_ID =
@@ -76,11 +70,11 @@ class IacasServiceTest {
                 "Certificate ID should match expected value");
         assertTrue(iaca.active(), "Certificate should be active");
         assertEquals(
-                "-----BEGIN CERTIFICATE-----MIICzzCCAnWgAwIBAgIUFBD7/XkDw4D/UTy7/pf1Q7c43/kwCgYIKoZIzj0EAwIwgbwxCzAJBgNVBAYTAlVLMQ8wDQYDVQQIDAZMb25kb24xNDAyBgNVBAoMK21ETCBFeGFtcGxlIElBQ0EgUm9vdCAtIERFTE9DQUwgZW52aXJvbm1lbnQxMjAwBgNVBAsMKW1ETCBFeGFtcGxlIElBQ0EgUm9vdCAtIExPQ0FMIGVudmlyb25tZW50MTIwMAYDVQQDDCltREwgRXhhbXBsZSBJQUNBIFJvb3QgLSBMT0NBTCBlbnZpcm9ubWVudDAeFw0yNTA2MTkxMTA4NTFaFw0zNTA2MTcxMTA4NTFaMIG8MQswCQYDVQQGEwJVSzEPMA0GA1UECAwGTG9uZG9uMTQwMgYDVQQKDCttREwgRXhhbXBsZSBJQUNBIFJvb3QgLSBERUxPQ0FMIGVudmlyb25tZW50MTIwMAYDVQQLDCltREwgRXhhbXBsZSBJQUNBIFJvb3QgLSBMT0NBTCBlbnZpcm9ubWVudDEyMDAGA1UEAwwpbURMIEV4YW1wbGUgSUFDQSBSb290IC0gTE9DQUwgZW52aXJvbm1lbnQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATK8ZrETZ7FQXw3+xj7fLV2yv1vFLOlZE0r2MQ0ysBOa/uZ7dUlOCvROTt5fpDR9e+Hdq0h9trZwwBY2HODAWVbo1MwUTAdBgNVHQ4EFgQUnelQVCApK3NIxVeQ3X+zUsogQxgwHwYDVR0jBBgwFoAUnelQVCApK3NIxVeQ3X+zUsogQxgwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiBwnpi6jeCSLxZgFeFLSN+zaG3zj9t6QcGFklY521tMtQIhAOF65mV0uski5+50FtKkJcVnS/1EDGrgor5bFeZDvdAI-----END CERTIFICATE-----",
+                TEST_CERTIFICATE_PEM,
                 iaca.certificatePem(),
                 "Certificate PEM should match expected value");
         assertEquals(
-                "62c8cec7894b4dad6ead9301644aacdec5cf864638d7d65790c5c1f152cd1507",
+                "3907132c3fccd8335625580cf3dce8a3498e578a2f06cd8ed33e05d570e402bf",
                 iaca.certificateFingerprint(),
                 "Certificate fingerprint should match expected value");
         assertInstanceOf(


### PR DESCRIPTION
## Proposed changes
### What changed
- Stopped stripping line breaks `(\n`) from certificates.

### Why did it change
- Certificates are expected to have line breaks after every 64 characters, with the last line potentially shorter.
- Stripping line breaks results in invalid certificate formatting, causing parsing or validation errors.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-14702](https://govukverify.atlassian.net/browse/DCMAW-14702)

## Testing
Branch deployed to the `dev` environment.

<img width="1080" height="584" alt="Screenshot 2025-09-03 at 18 26 45" src="https://github.com/user-attachments/assets/da1c1ef7-953c-42ff-b524-3eadcef0307c" />


## Checklist
- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-14702]: https://govukverify.atlassian.net/browse/DCMAW-14702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ