### PR TITLE
feat: update kms policy 

### DIFF
--- a/document-signing-certificate-issuer/template.yaml
+++ b/document-signing-certificate-issuer/template.yaml
@@ -265,8 +265,8 @@ Resources:
             Principal:
               AWS: arn:aws:iam::921104553881:role/wallet-cred-issuer-be-WalletBEECSTaskRole-bSAppwk9KqvA
             Action:
-              - kms:Sign
-              - kms:GetPublicKey
+              - 'kms:Sign'
+              - 'kms:DescribeKey'
             Resource: '*'
 
   DocumentSigningKeyAlias1:

--- a/document-signing-certificate-issuer/template.yaml
+++ b/document-signing-certificate-issuer/template.yaml
@@ -260,6 +260,12 @@ Resources:
       KeyPolicy:
         Version: '2012-10-17'
         Statement:
+          - Sid: EnableAccountRoot
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: 'kms:*'
+            Resource: '*'
           - Sid: AllowWalletBEECSTaskRoleToSign
             Effect: Allow
             Principal:

--- a/document-signing-certificate-issuer/template.yaml
+++ b/document-signing-certificate-issuer/template.yaml
@@ -242,7 +242,8 @@ Resources:
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
-          - Effect: Allow
+          - Sid: AllowWalletBEECSTaskRoleToGetObject
+            Effect: Allow
             Principal:
               AWS: arn:aws:iam::921104553881:role/wallet-cred-issuer-be-WalletBEECSTaskRole-bSAppwk9KqvA
             Action: 's3:GetObject'
@@ -259,21 +260,13 @@ Resources:
       KeyPolicy:
         Version: '2012-10-17'
         Statement:
-          - Sid: EnableAccountRoot
-            Effect: Allow
-            Principal:
-              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
-            Action: 'kms:*'
-            Resource: '*'
-
-          - Sid: AllowWalletIssuerRoleToSign
+          - Sid: AllowWalletBEECSTaskRoleToSign
             Effect: Allow
             Principal:
               AWS: arn:aws:iam::921104553881:role/wallet-cred-issuer-be-WalletBEECSTaskRole-bSAppwk9KqvA
             Action:
               - kms:Sign
               - kms:GetPublicKey
-              - kms:DescribeKey
             Resource: '*'
 
   DocumentSigningKeyAlias1:

--- a/document-signing-certificate-issuer/template.yaml
+++ b/document-signing-certificate-issuer/template.yaml
@@ -235,6 +235,19 @@ Resources:
               NoncurrentDays: 14
             Status: Enabled
 
+  DocSigningCertificateBucketPolicy:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref DocSigningCertificateBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: arn:aws:iam::921104553881:role/wallet-cred-issuer-be-WalletBEECSTaskRole-bSAppwk9KqvA
+            Action: 's3:GetObject'
+            Resource: !Sub '${DocSigningCertificateBucket.Arn}/*'
+
   DocumentSigningKey1:
     Type: AWS::KMS::Key
     Properties:
@@ -243,6 +256,25 @@ Resources:
       Description: !Sub 'Example Document Signing Key 1 for ${AWS::StackName}'
       Enabled: true
       PendingWindowInDays: 7
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EnableAccountRoot
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: 'kms:*'
+            Resource: '*'
+
+          - Sid: AllowWalletIssuerRoleToSign
+            Effect: Allow
+            Principal:
+              AWS: arn:aws:iam::921104553881:role/wallet-cred-issuer-be-WalletBEECSTaskRole-bSAppwk9KqvA
+            Action:
+              - kms:Sign
+              - kms:GetPublicKey
+              - kms:DescribeKey
+            Resource: '*'
 
   DocumentSigningKeyAlias1:
     Type: AWS::KMS::Alias


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->

- add a bucket policy to DocSigningCertificateBucket that grants the staging account access
- adding a kms policy that grants the staging account access

### Why did it change
<!-- Describe the reason these changes were made -->
The Example CRI returns 500 Internal Server Error when an mDL credential is requested because the staging WalletBEECSTaskRole is unable to fetch the document signing certificate from the build DocSigningCertificateBucket S3 bucket. This implementation is to resolve this issue.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-15295](https://govukverify.atlassian.net/browse/DCMAW-[15295](https://govukverify.atlassian.net/browse/DCMAW-15295))
Related PR https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/pull/341
## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-15295]: https://govukverify.atlassian.net/browse/DCMAW-15295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ