### PR TITLE
fix: add kms permission for the account root

### DIFF
--- a/document-signing-certificate-issuer/template.yaml
+++ b/document-signing-certificate-issuer/template.yaml
@@ -260,6 +260,12 @@ Resources:
       KeyPolicy:
         Version: '2012-10-17'
         Statement:
+          - Sid: EnableAccountRoot
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: 'kms:*'
+            Resource: '*'
           - Sid: AllowWalletBEECSTaskRoleToSign
             Effect: Allow
             Principal:


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->

- adding a kms policy that grants permission to the account root

### Why did it change
<!-- Describe the reason these changes were made -->
This is to resolve a pipeline build failure to update kms policy 
### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

**Related PR** https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/pull/341

- [DCMAW-15295](https://govukverify.atlassian.net/browse/DCMAW-15295)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-15295]: https://govukverify.atlassian.net/browse/DCMAW-15295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ