### PR TITLE
feat: Remove extra 'credential' attribute from Credential Response

### DIFF
--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/CredentialResponse.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/CredentialResponse.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 @Getter
 public class CredentialResponse {
-    private final String credential;
     private final ArrayList<Credential> credentials;
 
     @JsonProperty("notification_id")
@@ -19,7 +18,6 @@ public class CredentialResponse {
     public CredentialResponse(
             @JsonProperty("credential") String credential,
             @JsonProperty("notification_id") String notificationId) {
-        this.credential = credential;
         this.notificationId = notificationId;
         this.credentials = new ArrayList<>(List.of(new Credential(credential)));
     }

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialResourceTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialResourceTest.java
@@ -269,7 +269,6 @@ class CredentialResourceTest {
         assertThat(
                 credentialResponse.getCredentials().get(0).getCredentialObj(),
                 is(EXPECTED_CREDENTIAL_JWT));
-        assertThat(credentialResponse.getCredential(), is(EXPECTED_CREDENTIAL_JWT));
         assertThat(credentialResponse.getNotificationId(), is(EXPECTED_NOTIFICATION_ID));
     }
 }

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialServiceTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialServiceTest.java
@@ -219,7 +219,9 @@ class CredentialServiceTest {
         CredentialResponse credentialServiceReturnValue =
                 credentialService.getCredential(mockAccessToken, mockProofJwt);
 
-        assertEquals(mockCredentialJwt, credentialServiceReturnValue.getCredential());
+        assertEquals(
+                mockCredentialJwt,
+                credentialServiceReturnValue.getCredentials().get(0).getCredentialObj());
         assertEquals("3fwe98js", NOTIFICATION_ID);
         verify(mockAccessTokenService).verifyAccessToken(mockAccessToken);
         verify(mockProofJwtService).verifyProofJwt(mockProofJwt);


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->
- Remove the top-level credential (singular) property from the credential endpoint response.
### Why did it change
<!-- Describe the reason these changes were made -->
This implementation is to align the credential endpoint response with the [OID4VCI specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-issuer-metadata-p).
### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-11895](https://govukverify.atlassian.net/browse/DCMAW-11895)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->
##### Nino credential - Tested locally (all documents has been tested but not included)
<img width="1618" height="165" alt="Screenshot 2025-09-29 at 12 56 01" src="https://github.com/user-attachments/assets/55f60788-35eb-4373-afb7-a752b2387fc1" />

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-11895]: https://govukverify.atlassian.net/browse/DCMAW-11895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ