### PR TITLE
fix: fixing a failed deployment when updated credential response

### DIFF
--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialServiceTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/credential/CredentialServiceTest.java
@@ -219,6 +219,7 @@ class CredentialServiceTest {
         CredentialResponse credentialServiceReturnValue =
                 credentialService.getCredential(mockAccessToken, mockProofJwt);
 
+        // update credential response return value to be credential object
         assertEquals(
                 mockCredentialJwt,
                 credentialServiceReturnValue.getCredentials().get(0).getCredentialObj());


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->
Added a comment which will be removed later.
### Why did it change
<!-- Describe the reason these changes were made -->
This is to fix deployment failure for this PR https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/pull/353
Failure happened because of a single quote in the commit message.
### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-11895](https://govukverify.atlassian.net/browse/DCMAW-11895)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
