### PR TITLE
feat: temporarily remove `notification_id` case sensitive equality check

### DIFF
--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/notification/NotificationService.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/notification/NotificationService.java
@@ -44,7 +44,7 @@ public class NotificationService {
 
         if (!storedCredential
                 .getNotificationId()
-                .equals(notificationRequestBody.getNotificationId())) {
+                .equalsIgnoreCase(notificationRequestBody.getNotificationId())) {
             throw new InvalidNotificationIdException(
                     "Request 'notification_id' does not match cached 'notificationId'");
         }

--- a/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/notification/NotificationServiceTest.java
+++ b/example-credential-issuer/src/test/java/uk/gov/di/mobile/wallet/cri/notification/NotificationServiceTest.java
@@ -145,6 +145,37 @@ class NotificationServiceTest {
     }
 
     @Test
+    void Should_Match_When_NotificationIDsAreOfDifferentCasing()
+            throws DataStoreException,
+                    AccessTokenValidationException,
+                    InvalidNotificationIdException {
+        String requestNotificationId = "6A6BB0DC-C6CB-4FD1-8C03-08423E38802A";
+        requestBody =
+                new NotificationRequestBody(
+                        requestNotificationId, EventType.credential_accepted, "Credential stored");
+
+        String storedNotificationId = "6a6bb0dc-c6cb-4fd1-8c03-08423e38802a";
+        StoredCredential mockStoredCredential =
+                new StoredCredential(
+                        CREDENTIAL_IDENTIFIER,
+                        storedNotificationId,
+                        WALLET_SUBJECT_ID,
+                        43200L,
+                        DOCUMENT_PRIMARY_IDENTIFIER);
+        when(mockDynamoDbService.getStoredCredential(anyString())).thenReturn(mockStoredCredential);
+        notificationService.processNotification(accessToken, requestBody);
+        verify(mockLogger)
+                .info(
+                        "Notification received - notification_id: {}, event: {}, event_description: {}",
+                        "6A6BB0DC-C6CB-4FD1-8C03-08423E38802A",
+                        EventType.credential_accepted,
+                        "Credential stored");
+
+        verify(mockAccessTokenService, times(1)).verifyAccessToken(accessToken);
+        verify(mockDynamoDbService, times(1)).getStoredCredential(CREDENTIAL_IDENTIFIER);
+    }
+
+    @Test
     void Should_LogNotification_When_RequestIsValid()
             throws DataStoreException,
                     AccessTokenValidationException,


### PR DESCRIPTION
## Proposed changes
### What changed
- Temporary remove the `notification_id` case sensitive equality check in the NotificationService.

### Why did it change
- The iOS app is converting the `notification_id` to upper case before sending it to the notification endpoint, and this works for MoD. The Example CRI must match the MoD CRI behaviour until a validation approach is agreed.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-15932](https://govukverify.atlassian.net/browse/DCMAW-15932)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-15932]: https://govukverify.atlassian.net/browse/DCMAW-15932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ