### PR TITLE
feat: Add revoke resource

### DIFF
--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/responses/ResponseUtil.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/responses/ResponseUtil.java
@@ -52,6 +52,18 @@ public class ResponseUtil {
                 .build();
     }
 
+    public static Response accepted() {
+        return Response.status(Response.Status.ACCEPTED)
+                .header(HttpHeaders.CACHE_CONTROL, NO_STORE)
+                .build();
+    }
+
+    public static Response notFound() {
+        return Response.status(Response.Status.NOT_FOUND)
+                .header(HttpHeaders.CACHE_CONTROL, NO_STORE)
+                .build();
+    }
+
     private static Response.ResponseBuilder jsonBuilder(Response.Status status, Object entity) {
         return Response.status(status)
                 .entity(entity)

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeRequestBody.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeRequestBody.java
@@ -6,11 +6,11 @@ import lombok.Getter;
 
 @Getter
 public class RevokeRequestBody {
-    @JsonProperty("driving_licence_number")
+    @JsonProperty("drivingLicenceNumber")
     private String drivingLicenceNumber;
 
     @JsonCreator
-    public RevokeRequestBody(@JsonProperty(value = "driving_licence_number", required = true) String drivingLicenceNumber) {
+    public RevokeRequestBody(@JsonProperty(value = "drivingLicenceNumber", required = true) String drivingLicenceNumber) {
         this.drivingLicenceNumber = drivingLicenceNumber;
     }
 }

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeRequestBody.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeRequestBody.java
@@ -1,0 +1,16 @@
+package uk.gov.di.mobile.wallet.cri.revoke;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class RevokeRequestBody {
+    @JsonProperty("driving_licence_number")
+    private String drivingLicenceNumber;
+
+    @JsonCreator
+    public RevokeRequestBody(@JsonProperty(value = "driving_licence_number", required = true) String drivingLicenceNumber) {
+        this.drivingLicenceNumber = drivingLicenceNumber;
+    }
+}

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeRequestBody.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeRequestBody.java
@@ -10,7 +10,9 @@ public class RevokeRequestBody {
     private String drivingLicenceNumber;
 
     @JsonCreator
-    public RevokeRequestBody(@JsonProperty(value = "drivingLicenceNumber", required = true) String drivingLicenceNumber) {
+    public RevokeRequestBody(
+            @JsonProperty(value = "drivingLicenceNumber", required = true)
+                    String drivingLicenceNumber) {
         this.drivingLicenceNumber = drivingLicenceNumber;
     }
 }

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeResource.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeResource.java
@@ -1,8 +1,5 @@
 package uk.gov.di.mobile.wallet.cri.revoke;
 
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -13,9 +10,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.mobile.wallet.cri.responses.ResponseUtil;
 import uk.gov.di.mobile.wallet.cri.services.data_storage.DataStoreException;
-
-import javax.security.auth.login.CredentialNotFoundException;
-
 
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
@@ -40,11 +34,10 @@ public class RevokeResource {
             return ResponseUtil.accepted();
         } catch (Exception exception) {
             LOGGER.error("An Error happened getting driving licence number", exception);
-            if(exception instanceof RevokeServiceException) {
+            if (exception instanceof RevokeServiceException) {
                 return ResponseUtil.notFound();
             }
             return ResponseUtil.internalServerError();
         }
     }
-
 }

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeResource.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeResource.java
@@ -1,0 +1,50 @@
+package uk.gov.di.mobile.wallet.cri.revoke;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.mobile.wallet.cri.responses.ResponseUtil;
+import uk.gov.di.mobile.wallet.cri.services.data_storage.DataStoreException;
+
+import javax.security.auth.login.CredentialNotFoundException;
+
+
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/revoke")
+public class RevokeResource {
+
+    private final RevokeService revokeService;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RevokeResource.class);
+
+    public RevokeResource(RevokeService revokeService) {
+        this.revokeService = revokeService;
+    }
+
+    @POST
+    public Response revokeCredential(RevokeRequestBody body) throws DataStoreException {
+        if (body == null) {
+            return ResponseUtil.badRequest("Driving Licence Number not found");
+        }
+        try {
+            revokeService.revokeCredential(body.getDrivingLicenceNumber());
+            return ResponseUtil.accepted();
+        } catch (Exception exception) {
+            LOGGER.error("An Error happened getting driving licence number", exception);
+            if(exception instanceof RevokeServiceException) {
+                return ResponseUtil.notFound();
+            }
+            return ResponseUtil.internalServerError();
+        }
+    }
+
+}

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeService.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeService.java
@@ -1,0 +1,30 @@
+package uk.gov.di.mobile.wallet.cri.revoke;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.mobile.wallet.cri.notification.NotificationService;
+import uk.gov.di.mobile.wallet.cri.services.data_storage.DataStore;
+import uk.gov.di.mobile.wallet.cri.services.data_storage.DataStoreException;
+
+
+public class RevokeService {
+
+    private final DataStore dataStore;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NotificationService.class);
+
+    public RevokeService(DataStore dataStore) {
+        this.dataStore = dataStore;
+    }
+
+    public void revokeCredential(RevokeRequestBody revokeRequestBody) throws DataStoreException{
+        if (revokeRequestBody == null) {
+            throw new DataStoreException("Request body is null");
+        }
+
+        String documentPrimaryIdentifierValue = revokeRequestBody.getDrivingLicenceNumber();
+
+        dataStore.getCredentialsByDocumentPrimaryIdentifier(documentPrimaryIdentifierValue);
+
+    }
+}

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeService.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeService.java
@@ -6,7 +6,6 @@ import uk.gov.di.mobile.wallet.cri.notification.NotificationService;
 import uk.gov.di.mobile.wallet.cri.services.data_storage.DataStore;
 import uk.gov.di.mobile.wallet.cri.services.data_storage.DataStoreException;
 
-
 public class RevokeService {
 
     private final DataStore dataStore;
@@ -17,12 +16,11 @@ public class RevokeService {
         this.dataStore = dataStore;
     }
 
-    public void revokeCredential(String documentPrimaryIdentifier) throws DataStoreException{
+    public void revokeCredential(String documentPrimaryIdentifier) throws DataStoreException {
         if (documentPrimaryIdentifier == null) {
             throw new DataStoreException("Document primary identifier is null");
         }
 
         dataStore.getCredentialsByDocumentPrimaryIdentifier(documentPrimaryIdentifier);
-
     }
 }

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeService.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeService.java
@@ -17,14 +17,12 @@ public class RevokeService {
         this.dataStore = dataStore;
     }
 
-    public void revokeCredential(RevokeRequestBody revokeRequestBody) throws DataStoreException{
-        if (revokeRequestBody == null) {
-            throw new DataStoreException("Request body is null");
+    public void revokeCredential(String documentPrimaryIdentifier) throws DataStoreException{
+        if (documentPrimaryIdentifier == null) {
+            throw new DataStoreException("Document primary identifier is null");
         }
 
-        String documentPrimaryIdentifierValue = revokeRequestBody.getDrivingLicenceNumber();
-
-        dataStore.getCredentialsByDocumentPrimaryIdentifier(documentPrimaryIdentifierValue);
+        dataStore.getCredentialsByDocumentPrimaryIdentifier(documentPrimaryIdentifier);
 
     }
 }

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeServiceException.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeServiceException.java
@@ -4,5 +4,4 @@ public class RevokeServiceException extends RuntimeException {
     public RevokeServiceException(String message) {
         super(message);
     }
-
 }

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeServiceException.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/revoke/RevokeServiceException.java
@@ -1,0 +1,8 @@
+package uk.gov.di.mobile.wallet.cri.revoke;
+
+public class RevokeServiceException extends RuntimeException {
+    public RevokeServiceException(String message) {
+        super(message);
+    }
+
+}

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/services/data_storage/DataStore.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/services/data_storage/DataStore.java
@@ -17,6 +17,6 @@ public interface DataStore {
 
     StoredCredential getStoredCredential(String credentialId) throws DataStoreException;
 
-    List<StoredCredential> getCredentialsByDocumentPrimaryIdentifier(String documentPrimaryIdentifier) throws DataStoreException;
-
+    List<StoredCredential> getCredentialsByDocumentPrimaryIdentifier(
+            String documentPrimaryIdentifier) throws DataStoreException;
 }

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/services/data_storage/DataStore.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/services/data_storage/DataStore.java
@@ -3,6 +3,8 @@ package uk.gov.di.mobile.wallet.cri.services.data_storage;
 import uk.gov.di.mobile.wallet.cri.models.CachedCredentialOffer;
 import uk.gov.di.mobile.wallet.cri.models.StoredCredential;
 
+import java.util.List;
+
 public interface DataStore {
 
     void saveCredentialOffer(CachedCredentialOffer cachedCredentialOffer) throws DataStoreException;
@@ -14,4 +16,7 @@ public interface DataStore {
     void saveStoredCredential(StoredCredential storedCredential) throws DataStoreException;
 
     StoredCredential getStoredCredential(String credentialId) throws DataStoreException;
+
+    List<StoredCredential> getCredentialsByDocumentPrimaryIdentifier(String documentPrimaryIdentifier) throws DataStoreException;
+
 }

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/services/data_storage/DynamoDbService.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/services/data_storage/DynamoDbService.java
@@ -1,10 +1,6 @@
 package uk.gov.di.mobile.wallet.cri.services.data_storage;
 
-import org.eclipse.jetty.util.Index;
-import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.enhanced.dynamodb.*;
-import software.amazon.awssdk.enhanced.dynamodb.model.Page;
-import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
@@ -104,21 +100,28 @@ public class DynamoDbService implements DataStore {
     }
 
     @Override
-    public List<StoredCredential> getCredentialsByDocumentPrimaryIdentifier(String documentPrimaryIdentifier) throws DataStoreException {
+    public List<StoredCredential> getCredentialsByDocumentPrimaryIdentifier(
+            String documentPrimaryIdentifier) throws DataStoreException {
         try {
-            DynamoDbIndex<StoredCredential> index = storedCredentialTable.index("documentPrimaryIdentifierIndex");
+            DynamoDbIndex<StoredCredential> index =
+                    storedCredentialTable.index("documentPrimaryIdentifierIndex");
 
-            QueryEnhancedRequest request = QueryEnhancedRequest.builder()
-                    .queryConditional(QueryConditional.keyEqualTo(
-                            Key.builder().partitionValue(documentPrimaryIdentifier).build()
-                    )).build();
+            QueryEnhancedRequest request =
+                    QueryEnhancedRequest.builder()
+                            .queryConditional(
+                                    QueryConditional.keyEqualTo(
+                                            Key.builder()
+                                                    .partitionValue(documentPrimaryIdentifier)
+                                                    .build()))
+                            .build();
 
             var credential = index.query(request).iterator();
 
             return new ArrayList<>(credential.next().items());
 
-        }  catch (Exception exception) {
-            throw new DataStoreException("Error fetching list of credentials by documentPrimaryIdentifier", exception);
+        } catch (Exception exception) {
+            throw new DataStoreException(
+                    "Error fetching list of credentials by documentPrimaryIdentifier", exception);
         }
     }
 

--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/services/data_storage/DynamoDbService.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/services/data_storage/DynamoDbService.java
@@ -106,16 +106,13 @@ public class DynamoDbService implements DataStore {
     @Override
     public List<StoredCredential> getCredentialsByDocumentPrimaryIdentifier(String documentPrimaryIdentifier) throws DataStoreException {
         try {
-            // Access the GSI
             DynamoDbIndex<StoredCredential> index = storedCredentialTable.index("documentPrimaryIdentifierIndex");
 
-            // Build the query against the GSI
             QueryEnhancedRequest request = QueryEnhancedRequest.builder()
                     .queryConditional(QueryConditional.keyEqualTo(
                             Key.builder().partitionValue(documentPrimaryIdentifier).build()
                     )).build();
 
-            // collect and iterate over all items
             var credential = index.query(request).iterator();
 
             return new ArrayList<>(credential.next().items());


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->

- Add `/revoke` endpoint resource that accepts `POST` requests and `application/json`
- Add `RevokeRequestBody` containing a driving licence number: {"drivingLicenceNumber": "xxxxxxxxxx"} 
- Add `RevokeService`
- Update `DataStore` and `DynamoDBService` to get list of credentials
- Validate request body to ensure it contains a driving licence number

- ### Why did it change
<!-- Describe the reason these changes were made -->
This implementation is part of updating CRI to enable Status List Mock
### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-14826](https://govukverify.atlassian.net/browse/DCMAW-14826)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
