### PR TITLE
fix: use commandLine utility to execute docker commands

### DIFF
--- a/example-credential-issuer/README.md
+++ b/example-credential-issuer/README.md
@@ -81,7 +81,7 @@ This app uses LocalStack to run AWS services (DynamoDB and KMS) locally on port 
 To start the LocalStack container and emulate the services, run:
 
 ```
-./gradlew dockerUp
+./gradlew localstackUp
 ```
 
 ##### Run the Application

--- a/example-credential-issuer/build.gradle
+++ b/example-credential-issuer/build.gradle
@@ -128,22 +128,14 @@ tasks.withType(Test).configureEach {
 }
 
 
-tasks.register("dockerUp") {
+tasks.register("localstackUp", Exec) {
 	group = "docker"
 	description = "Starts the LocalStack container to emulate AWS services"
-	doLast {
-		exec {
-			commandLine "sh", "-c", "docker compose -f docker-compose.yml up --build -d --wait"
-		}
-	}
+	commandLine "sh", "-c", "docker compose -f docker-compose.yml up --build -d --wait"
 }
 
-tasks.register("dockerDown") {
+tasks.register("localstackDown", Exec) {
 	group = "docker"
 	description = "Stops and removes LocalStack container"
-	doLast {
-		exec {
-			commandLine "sh", "-c", "docker compose -f docker-compose.yml down"
-		}
-	}
+	commandLine "sh", "-c", "docker compose -f docker-compose.yml down"
 }


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->
use commandLine utility to execute docker commands

### Why did it change
<!-- Describe the reason these changes were made -->

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-19588](https://govukverify.atlassian.net/browse/DCMAW-19588)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-19588]: https://govukverify.atlassian.net/browse/DCMAW-19588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ