### PR TITLE
fix: map portrait to photo in veteran card

### DIFF
--- a/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/jwt/digital_veteran_card/VeteranCardDocument.java
+++ b/example-credential-issuer/src/main/java/uk/gov/di/mobile/wallet/cri/credential/jwt/digital_veteran_card/VeteranCardDocument.java
@@ -33,5 +33,7 @@ public class VeteranCardDocument {
 
     private String serviceNumber;
     private String serviceBranch;
+
+    @JsonProperty("portrait")
     private String photo;
 }


### PR DESCRIPTION
## Proposed changes
### What changed
Mapped portrait to photo in veteran card.

### Why did it change
To align with the field rename in Document builder: Veteran card's change(photo->portrait).

### Issue tracking
- [DCMAW-19651](https://govukverify.atlassian.net/browse/DCMAW-19651)

## Testing
Tested it locally and in dev.(proof is attached in PR doc builder)

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

[DCMAW-19651]: https://govukverify.atlassian.net/browse/DCMAW-19651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ