### PR TITLE
fix: add right command for now to run cri locally against test harness

### DIFF
--- a/example-credential-issuer/README.md
+++ b/example-credential-issuer/README.md
@@ -88,7 +88,7 @@ The service will be available at http://localhost:8080.
 
 The [test harness](https://github.com/govuk-one-login/mobile-wallet-cri-test-harness) contains a mock of the GOV.UK One Login authorization server. You must configure your authorization server URL to point to the mock:
 
-`ONE_LOGIN_AUTH_SERVER_URL=http://localhost:3001 ./gradlew run`.
+`ONE_LOGIN_AUTH_SERVER_URL=http://localhost:3001 ONE_LOGIN_AUTH_SERVER_URLS=http://localhost:3001 ./gradlew run`.
 
 ## Deployment
 


### PR DESCRIPTION
## Proposed changes
### What changed
Added the right command to run Example CRI locally against Test Harness.

### Why did it change
Because Example CRI is configured to run with multiple urls.

### Issue tracking

## Testing


## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [x] Documentation (e.g. README.md) has been updated

