### PR TITLE
docs: update command for testing example cri with test harness

### DIFF
--- a/example-credential-issuer/README.md
+++ b/example-credential-issuer/README.md
@@ -88,7 +88,7 @@ The service will be available at http://localhost:8080.
 
 The [test harness](https://github.com/govuk-one-login/mobile-wallet-cri-test-harness) contains a mock of the GOV.UK One Login authorization server. You must configure your authorization server URL to point to the mock:
 
-`ONE_LOGIN_AUTH_SERVER_URL=http://localhost:3001 ./gradlew run`.
+`ONE_LOGIN_AUTH_SERVER_URL=http://localhost:3001 ONE_LOGIN_AUTH_SERVER_URLS=http://localhost:3001 ./gradlew run`.
 
 ## Deployment
 

--- a/example-credential-issuer/README.md
+++ b/example-credential-issuer/README.md
@@ -90,7 +90,7 @@ The service will be available at http://localhost:8080.
 
 ##### Testing with the Example CRI Test Harness
 
-The [test harness](https://github.com/govuk-one-login/mobile-wallet-cri-test-harness) contains a mock of the GOV.UK One Login authorization server. You must configure your authorization server URL to point to the mock:
+The [test harness](https://github.com/govuk-one-login/mobile-wallet-cri-test-harness) contains a mock of the GOV.UK One Login authorization server. You must configure your authorization server URLs to point to the mock and set the environment to `ci`:
 
 `ONE_LOGIN_AUTH_SERVER_URL=http://localhost:3001 ONE_LOGIN_AUTH_SERVER_URLS=http://localhost:3001 ENVIRONMENT=ci ./gradlew run`.
 

--- a/example-credential-issuer/README.md
+++ b/example-credential-issuer/README.md
@@ -88,7 +88,7 @@ The service will be available at http://localhost:8080.
 
 The [test harness](https://github.com/govuk-one-login/mobile-wallet-cri-test-harness) contains a mock of the GOV.UK One Login authorization server. You must configure your authorization server URL to point to the mock:
 
-`ONE_LOGIN_AUTH_SERVER_URL=http://localhost:3001 ONE_LOGIN_AUTH_SERVER_URLS=http://localhost:3001 ./gradlew run`.
+`ONE_LOGIN_AUTH_SERVER_URL=http://localhost:3001 ONE_LOGIN_AUTH_SERVER_URLS=http://localhost:3001 ENVIRONMENT=ci ./gradlew run`.
 
 ## Deployment
 


### PR DESCRIPTION
## Proposed changes
### What changed
The command is updated in Testing with the Example CRI Test Harness section in README.md file.

### Why did it change
By default, the example CRI runs with `ENVIRONMENT=local`, which skips access token signature verification. The test harness expects this verification to be active and tests a 401 response for tokens with invalid signatures — when verification is skipped, the endpoint returns 200 and the tests fail. Setting `ENVIRONMENT=ci` enables access token signature verification and allows the test harness tests to pass.

### Issue tracking
- [DCMAW-20018](https://govukverify.atlassian.net/browse/DCMAW-20018)

## Testing


## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [x] Documentation (e.g. README.md) has been updated

[DCMAW-20018]: https://govukverify.atlassian.net/browse/DCMAW-20018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ