### PR TITLE
ci: add minimal workflow to deploy Platform CA to dev

### DIFF
--- a/.github/workflows/platform-ca-dev-deploy.yml
+++ b/.github/workflows/platform-ca-dev-deploy.yml
@@ -1,0 +1,24 @@
+name: Platform CA - Deploy to Dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      gitRef:
+        description: Input branch name or commit SHA
+        required: true
+        type: string
+        default: main
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.gitRef }}


### PR DESCRIPTION
## Proposed changes
### What changed
- Added a minimal workflow to test the deployment of the Platform CA to the `dev` account in a subsequent PR https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/pull/523

### Why did it change
- As above.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-19911](https://govukverify.atlassian.net/browse/DCMAW-19911)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-19911]: https://govukverify.atlassian.net/browse/DCMAW-19911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ