### PR TITLE
chore(example-cri, document-builder): pin LocalStack Docker image version to 4.14

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -116,6 +116,9 @@ updates:
       - dependency-name: "node"
         update-types:
           - "version-update:semver-major"
+      - dependency-name: "localstack/localstack"
+        versions:
+          - "> 4.14.0" # Cannot be updated past 4.14.0 due to LocalStack’s move to a paid‑only license.
     commit-message:
       prefix: chore
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,10 @@ updates:
       docker-updates:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "localstack/localstack"
+        versions:
+          - "> 4.14.0" # Cannot be updated past 4.14.0 due to LocalStack’s move to a paid‑only license.
   - package-ecosystem: "npm"
     directory: "/document-signing-certificate-issuer"
     cooldown:

--- a/.github/workflows/document-builder-pull-request-checks.yml
+++ b/.github/workflows/document-builder-pull-request-checks.yml
@@ -2,6 +2,11 @@ name: Document Builder - Pull Request Checks
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
     paths:
       - document-builder/**
       - .github/workflows/document-builder-pull-request-checks.yml

--- a/.github/workflows/platform-ca-pull-request-checks.yml
+++ b/.github/workflows/platform-ca-pull-request-checks.yml
@@ -2,6 +2,11 @@ name: Platform CA - Pull Request Checks
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
     paths:
       - platform-ca/**
       - .github/workflows/platform-ca-pull-request-checks.yml

--- a/.github/workflows/test-harness-pull-request-checks.yml
+++ b/.github/workflows/test-harness-pull-request-checks.yml
@@ -7,12 +7,15 @@ on:
       - reopened
       - ready_for_review
       - synchronize
+    paths:
+      - test-harness-/**
+      - .github/workflows/test-harness-pull-request-checks.yml
   workflow_dispatch:
-        inputs:
-          gitRef:
-            description: Branch name or commit SHA
-            required: false
-            default: main
+    inputs:
+      gitRef:
+        description: Branch name or commit SHA
+        required: false
+        default: main
 
 permissions:
   id-token: write

--- a/document-builder/docker-compose.yml
+++ b/document-builder/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   localstack:
     container_name: localstack_documentBuilder
-    image: localstack/localstack:latest
+    image: localstack/localstack:4.14.0@sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a
     ports:
       - "4561:4566"
     environment:

--- a/example-credential-issuer/docker-compose.yml
+++ b/example-credential-issuer/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   localstack:
     container_name: localstack_credentialIssuer
-    image: localstack/localstack:4.12.0@sha256:0df3a97da57de03a588c05d9b8f390f15c7033fc7c4512f94619d344bc3cd317
+    image: localstack/localstack:4.14.0@sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a
     ports:
       - "4560:4566"
     environment:

--- a/example-credential-issuer/integration-tests/docker-compose.yml
+++ b/example-credential-issuer/integration-tests/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   localstack:
     container_name: localstack
-    image: localstack/localstack:4.12.0@sha256:0df3a97da57de03a588c05d9b8f390f15c7033fc7c4512f94619d344bc3cd317
+    image: localstack/localstack:4.14.0@sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a # Cannot be updated past 4.14.0 due to LocalStack's move to a paid-only license.
     ports:
       - "4566:4566"
     environment:


### PR DESCRIPTION
## Proposed changes
### What changed
- Update the Example CRI and Document Builder projects to use LocalStack version `4.14` and pin the image to digest `sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a`.
- Configure Dependabot so it does not propose updates for the LocalStack image.
- Add missing paths and types filters to PR workflows.

### Why did it change
- LocalStack has moved to a paid‑only license. Version `4.14` is the last free version.
- Avoid running the workflow for unrelated PR changes.
- Cover new PRs, updates, and draft-to-ready transitions.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-20469](https://govukverify.atlassian.net/browse/DCMAW-20469)

## Testing
**Tested locally end-to-end.**

LocalStack image version:
<img width="865" height="814" alt="Screenshot 2026-05-20 at 10 29 38" src="https://github.com/user-attachments/assets/6104f1bc-442b-4289-8594-7ee9ced9f889" />

mDl credential issued successfully:
<img width="1102" height="1104" alt="Screenshot 2026-05-20 at 10 40 47" src="https://github.com/user-attachments/assets/94c0feea-d6e3-4b6e-8c58-84720b620225" />
<img width="1029" height="1178" alt="Screenshot 2026-05-20 at 10 31 49" src="https://github.com/user-attachments/assets/7b88a553-65d4-4ba4-9108-2517b991d7b1" />

## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->

- https://github.com/govuk-one-login/mobile-wallet-onboarding-products-mocks/pull/38

[DCMAW-20469]: https://govukverify.atlassian.net/browse/DCMAW-20469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ