### PR TITLE
fix(test-harness): fix jest config and ESM import extensions

### DIFF
--- a/example-credential-issuer/README.md
+++ b/example-credential-issuer/README.md
@@ -109,5 +109,3 @@ Automated deployments to `build` are triggered on push to `main` after PR approv
 | Document                                           | Description |
 |----------------------------------------------------|---|
 | [`docs/infrastructure.md`](docs/infrastructure.md) | Infrastructure diagram — AWS architecture, API routes, data flow |
-
-TEST

--- a/example-credential-issuer/README.md
+++ b/example-credential-issuer/README.md
@@ -109,3 +109,5 @@ Automated deployments to `build` are triggered on push to `main` after PR approv
 | Document                                           | Description |
 |----------------------------------------------------|---|
 | [`docs/infrastructure.md`](docs/infrastructure.md) | Infrastructure diagram — AWS architecture, API routes, data flow |
+
+TEST

--- a/test-harness/jest.config.ts
+++ b/test-harness/jest.config.ts
@@ -1,7 +1,11 @@
 export default {
   setupFiles: ["reflect-metadata"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
   transform: {
-    "^.+\\.(js)$": ["ts-jest"],
+    "^.+\\.tsx?$": ["ts-jest", {}],
+    "^.+\\.js$": ["ts-jest", { diagnostics: false }],
   },
   reporters: [
     "default",

--- a/test-harness/src/app.ts
+++ b/test-harness/src/app.ts
@@ -1,6 +1,6 @@
 import express, { Application } from "express";
-import { initialiseKeyPair } from "./initialiseKeyPair";
-import { buildJwksResponse } from "./buildJwksResponse";
+import { initialiseKeyPair } from "./initialiseKeyPair.js";
+import { buildJwksResponse } from "./buildJwksResponse.js";
 
 const JWKS_ROUTE = "/.well-known/jwks.json";
 

--- a/test-harness/src/initialiseKeyPair.ts
+++ b/test-harness/src/initialiseKeyPair.ts
@@ -1,6 +1,6 @@
 import { exportJWK, generateKeyPair } from "jose";
 import { writeFile } from "node:fs/promises";
-import { getKeyId } from "./config";
+import { getKeyId } from "./config.js";
 
 export async function initialiseKeyPair() {
   const keyPair = await generateKeyPair("ES256", {

--- a/test-harness/src/server.ts
+++ b/test-harness/src/server.ts
@@ -1,5 +1,5 @@
-import { getPortNumber } from "./config";
-import { createApp } from "./app";
+import { getPortNumber } from "./config.js";
+import { createApp } from "./app.js";
 
 const port = getPortNumber();
 const app = await createApp();


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->
Fixing the test harness after server.ts refactor
* app.ts, initialiseKeyPair.ts, server.ts — fixing .js import extensions for ESM compatibility
* jest.config.ts — fixing broken unit tests

### Why did it change
<!-- Describe the reason these changes were made -->
The [refactor server commit](https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/commit/bf46121e442f113b0017c15a04e0b103de64d85c) introduced code which could not be executed at runtime due to ESM incompatibility. It also added unit tests but didn't correctly configure Jest to run them, and used inconsistent import extensions. This branch fixes both of those issues.


### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->
Evidence of test harness tests working in CI
<img width="1369" height="520" alt="image" src="https://github.com/user-attachments/assets/528fd3b2-b5c7-47f5-8a81-a7435d524ad2" />

(the test commit that triggered the above workflow has now bee removed)

mdoc tests passing locally
```
./run-test-harness.sh mdoc "https://mobile.build.account.gov.uk/wallet-test/add?....." --cri-url http://localhost:8080 --client-id TEST_CLIENT_ID

  Credential Issuer Tests
    Credential Offer
      when validating a provided credential offer
        ✓ should be valid credential offer (23 ms)
        ✓ should be valid pre-authorized code (22 ms)
    Metadata
      when requesting the credential issuer metadata
        ✓ should return 200 status code
        ✓ should return JSON content
        ✓ should return valid metadata (11 ms)
    did:web Document
      when requesting the credential issuer did:web document
        ○ skipped should return 200 status code
        ○ skipped should return JSON content
        ○ skipped should return valid did:web document
    IACAs
      when requesting the credential issuer IACAs
        ✓ should return 200 status code
        ✓ should return JSON content
        ✓ should return valid IACAs (11 ms)
    JWKS
      when requesting the credential issuer JWKS
        ✓ should return 200 status code
        ✓ should return JSON content
        ✓ should return valid JWKS (2 ms)
    Credential (Invalid Requests)
      when requesting a credential with invalid access token
        when the access token and credential offer wallet subject IDs do not match
          ✓ should return 401 with invalid_token error (77 ms)
        when the access token signature is invalid
          ✓ should return 401 with invalid_token error (12 ms)
      when requesting a credential with invalid proof JWT
        when the proof JWT signature is invalid
          ✓ should return 400 with invalid_proof error (9 ms)
        when the proof JWT nonce does not match the access token c_nonce
          ✓ should return 400 with invalid_nonce error (11 ms)
    Credential (Happy Path) & Notification
      Credential
        when requesting a credential with valid access token and proof JWT
          ✓ should return 200 status code
          ✓ should return JSON content (1 ms)
          ✓ should return valid response body
          ✓ should return notification_id (1 ms)
          ✓ should return valid mdoc credential (45 ms)
          ○ skipped should return valid JWT credential
      Notification
        when sending valid notifications
          ✓ should return 204 for credential_accepted event (17 ms)
          ✓ should return 204 for credential_deleted event (17 ms)
          ✓ should return 204 for credential_failure event (15 ms)
        when sending invalid notifications
          ✓ should return 400 for missing notification_id (5 ms)
          ✓ should return 400 for invalid event type (5 ms)
        when sending notifications with invalid authentication
          ✓ should return 401 for invalid access token (4 ms)
          ✓ should return 401 when no authentication is provided (4 ms)
    Credential (Redeeming Offer Twice)
      when a credential offer twice is redeemed twice
        ✓ should return 401 with invalid_token error (19 ms)

Test Suites: 1 passed, 1 total
Tests:       4 skipped, 28 passed, 32 total
Snapshots:   0 total
Time:        3.096 s
Ran all test suites matching te
```

JWT Tests passing locally 
```
> $ ./run-test-harness.sh jwt "https://mobile.build.account.gov.uk/wallet-test/add?...." --cri-url http://localhost:8080 --client-id TEST_CLIENT_ID

PASS test/credential-issuer-tests.test.ts
  Credential Issuer Tests
    Credential Offer
      when validating a provided credential offer
        ✓ should be valid credential offer (29 ms)
        ✓ should be valid pre-authorized code (34 ms)
    Metadata
      when requesting the credential issuer metadata
        ✓ should return 200 status code
        ✓ should return JSON content (1 ms)
        ✓ should return valid metadata (10 ms)
    did:web Document
      when requesting the credential issuer did:web document
        ✓ should return 200 status code
        ✓ should return JSON content
        ✓ should return valid did:web document (6 ms)
    IACAs
      when requesting the credential issuer IACAs
        ○ skipped should return 200 status code
        ○ skipped should return JSON content
        ○ skipped should return valid IACAs
    JWKS
      when requesting the credential issuer JWKS
        ✓ should return 200 status code
        ✓ should return JSON content
        ✓ should return valid JWKS (2 ms)
    Credential (Invalid Requests)
      when requesting a credential with invalid access token
        when the access token and credential offer wallet subject IDs do not match
          ✓ should return 401 with invalid_token error (77 ms)
        when the access token signature is invalid
          ✓ should return 401 with invalid_token error (9 ms)
      when requesting a credential with invalid proof JWT
        when the proof JWT signature is invalid
          ✓ should return 400 with invalid_proof error (11 ms)
        when the proof JWT nonce does not match the access token c_nonce
          ✓ should return 400 with invalid_nonce error (9 ms)
    Credential (Happy Path) & Notification
      Credential
        when requesting a credential with valid access token and proof JWT
          ✓ should return 200 status code (1 ms)
          ✓ should return JSON content
          ✓ should return valid response body (1 ms)
          ✓ should return notification_id
          ✓ should return valid JWT credential (17 ms)
          ○ skipped should return valid mdoc credential
      Notification
        when sending valid notifications
          ✓ should return 204 for credential_accepted event (15 ms)
          ✓ should return 204 for credential_deleted event (15 ms)
          ✓ should return 204 for credential_failure event (15 ms)
        when sending invalid notifications
          ✓ should return 400 for missing notification_id (4 ms)
          ✓ should return 400 for invalid event type (5 ms)
        when sending notifications with invalid authentication
          ✓ should return 401 for invalid access token (3 ms)
          ✓ should return 401 when no authentication is provided (4 ms)
    Credential (Redeeming Offer Twice)
      when a credential offer twice is redeemed twice
        ✓ should return 401 with invalid_token error (19 ms)

Test Suites: 1 passed, 1 total
Tests:       4 skipped, 28 passed, 32 total
Snapshots:   0 total
Time:        3.134 s
Ran all test suites matching test/credential-issuer-tests.test.ts.
```



## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
