### PR TITLE
feat(document-builder): added canary alarm

### DIFF
--- a/document-builder/deploy/template.yaml
+++ b/document-builder/deploy/template.yaml
@@ -761,6 +761,31 @@ Resources:
             Period: 60
             Stat: Minimum
 
+  DocBuilderHeartbeatAlarm:
+#    Condition: IsIntegration
+    Type: AWS::CloudWatch::Alarm  
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-DocBuilderHeartbeatAlarm"
+      AlarmDescription: "DocBuilder-Heartbeat Synthetic-Canary Alarm: Failed  GreaterThanOrEqualToThreshold 1"
+      MetricName: Failed  
+      Namespace: CloudWatchSynthetics  
+      Dimensions:  
+        - Name: CanaryName  
+          Value: document_builder_heartbeat  
+      Period: 3600  # max evaluation period: 1 hour. The canary runs every 3 hours.
+      EvaluationPeriods: 1  
+      Statistic: Average  
+      ComparisonOperator: GreaterThanOrEqualToThreshold  
+      Threshold: 1.0  
+      TreatMissingData: notBreaching  
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue alarm-sns-topic-warning
+      OKActions:
+        - !ImportValue alarm-sns-topic-warning
+      InsufficientDataActions: []
+
+
 Outputs:
   DocBuilderFriendlyUrl:
     Description: Friendly URL for the deployed doc builder service

--- a/document-builder/deploy/template.yaml
+++ b/document-builder/deploy/template.yaml
@@ -36,6 +36,8 @@ Conditions:
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]
 
+  IsIntegration: !Equals [!Ref Environment, integration]
+
   UsePermissionsBoundary:
     Fn::Not:
       - Fn::Equals:
@@ -762,7 +764,7 @@ Resources:
             Stat: Minimum
 
   DocBuilderHeartbeatAlarm:
-#    Condition: IsIntegration
+    Condition: IsIntegration
     Type: AWS::CloudWatch::Alarm  
     Properties:
       AlarmName: !Sub "${AWS::StackName}-DocBuilderHeartbeatAlarm"

--- a/document-builder/deploy/template.yaml
+++ b/document-builder/deploy/template.yaml
@@ -776,7 +776,7 @@ Resources:
           Value: document_builder_heartbeat  
       Period: 3600  # max evaluation period: 1 hour. The canary runs every 3 hours.
       EvaluationPeriods: 1  
-      Statistic: Average  
+      Statistic: Maximum  
       ComparisonOperator: GreaterThanOrEqualToThreshold  
       Threshold: 1.0  
       TreatMissingData: notBreaching  
@@ -785,8 +785,6 @@ Resources:
         - !ImportValue alarm-sns-topic-warning
       OKActions:
         - !ImportValue alarm-sns-topic-warning
-      InsufficientDataActions: []
-
 
 Outputs:
   DocBuilderFriendlyUrl:


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->

A synthetic canary has been created in dev (to test) and in Int. It is a heartbeat canary that looks for a 200 response on the url https://example-credential-issuer.wallet-onboarding.{ENV}.account.gov.uk/.well-known/openid-credential-issuer.

The canary runs every 3 hours Mon-Fri (omitting Saturday and Sunday)

An alarm has been created to detect failures in this canary - the alarm will be triggered if any failure is detected. The period for the alarm is 1hour, which is the max time we can give an alarm.

The alarm is conditionalised to only deploy to Int - we have deployed to dev to test.

### Why did it change
<!-- Describe the reason these changes were made -->

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-19810](https://govukverify.atlassian.net/browse/DCMAW-19810)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->
Alarm deployed into dev:

<img width="1134" height="601" alt="image" src="https://github.com/user-attachments/assets/bd974292-653e-4abf-862c-19cb45dcd8f5" />

Slack alarm for test in dev:

<img width="739" height="411" alt="image" src="https://github.com/user-attachments/assets/ef7c7345-ab53-4b95-bd90-c753a8b5b69a" />

Canary Set-up in Int:

<img width="1419" height="183" alt="image" src="https://github.com/user-attachments/assets/b3ec38af-af37-4c24-aa26-e06b4de9b732" />



## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-19810]: https://govukverify.atlassian.net/browse/DCMAW-19810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ