### PR TITLE
refactor(document-builder): replace raw environment strings with ENVIRONMENTS constant

### DIFF
--- a/document-builder/src/config/aws.ts
+++ b/document-builder/src/config/aws.ts
@@ -1,4 +1,5 @@
 import { getEnvironment, getAwsRegion } from "./appConfig";
+import { ENVIRONMENTS } from "./environments";
 import { LocalStackAwsConfig } from "../types/LocalStackAwsConfig";
 import { DynamoDBClientConfig } from "@aws-sdk/client-dynamodb";
 import { KMSClientConfig } from "@aws-sdk/client-kms";
@@ -20,7 +21,7 @@ export function getLocalStackAwsConfig(endpoint: string): LocalStackAwsConfig {
 }
 
 export function getDatabaseConfig(): DynamoDBClientConfig {
-  if (getEnvironment() === "local") {
+  if (getEnvironment() === ENVIRONMENTS.LOCAL) {
     logger.info("Running database locally");
     return getLocalStackAwsConfig(LOCALSTACK_ENDPOINT);
   }
@@ -31,7 +32,7 @@ export function getDatabaseConfig(): DynamoDBClientConfig {
 }
 
 export function getKmsConfig(): KMSClientConfig {
-  if (getEnvironment() === "local") {
+  if (getEnvironment() === ENVIRONMENTS.LOCAL) {
     logger.info("Running KMS locally");
     return getLocalStackAwsConfig(LOCALSTACK_ENDPOINT);
   }
@@ -42,7 +43,7 @@ export function getKmsConfig(): KMSClientConfig {
 }
 
 export function getS3Config(): S3ClientConfig {
-  if (getEnvironment() === "local") {
+  if (getEnvironment() === ENVIRONMENTS.LOCAL) {
     logger.info("Running S3 locally");
     return getLocalStackAwsConfig(LOCALSTACK_S3_ENDPOINT);
   }

--- a/document-builder/src/dbsDocumentBuilder/controller.ts
+++ b/document-builder/src/dbsDocumentBuilder/controller.ts
@@ -15,6 +15,7 @@ import { ERROR_CHOICES } from "../utils/errorChoices";
 import { getTimeToLiveEpoch } from "../utils/getTimeToLiveEpoch";
 import { ExpressRouteFunction } from "../types/ExpressRouteFunction";
 import { getViewCredentialOfferRedirectUrl } from "../utils/getViewCredentialOfferRedirectUrl";
+import { ENVIRONMENTS } from "../config/environments";
 
 const CREDENTIAL_TYPE = CredentialType.BasicDisclosureCredential;
 
@@ -27,7 +28,7 @@ export function dbsDocumentBuilderGetController({
 }: DbsDocumentBuilderControllerConfig = {}): ExpressRouteFunction {
   return async function (req: Request, res: Response): Promise<void> {
     try {
-      const showThrowError = environment !== "staging";
+      const showThrowError = environment !== ENVIRONMENTS.STAGE;
       res.render("dbs-document-details-form.njk", {
         authenticated: isAuthenticated(req),
         errorChoices: ERROR_CHOICES,

--- a/document-builder/src/ninoDocumentBuilder/controller.ts
+++ b/document-builder/src/ninoDocumentBuilder/controller.ts
@@ -15,6 +15,7 @@ import { ERROR_CHOICES } from "../utils/errorChoices";
 import { getTimeToLiveEpoch } from "../utils/getTimeToLiveEpoch";
 import { ExpressRouteFunction } from "../types/ExpressRouteFunction";
 import { getViewCredentialOfferRedirectUrl } from "../utils/getViewCredentialOfferRedirectUrl";
+import { ENVIRONMENTS } from "../config/environments";
 
 const CREDENTIAL_TYPE = CredentialType.SocialSecurityCredential;
 
@@ -27,7 +28,7 @@ export function ninoDocumentBuilderGetController({
 }: NinoDocumentBuilderControllerConfig = {}): ExpressRouteFunction {
   return async function (req: Request, res: Response): Promise<void> {
     try {
-      const showThrowError = environment !== "staging";
+      const showThrowError = environment !== ENVIRONMENTS.STAGE;
       res.render("nino-document-details-form.njk", {
         authenticated: isAuthenticated(req),
         errorChoices: ERROR_CHOICES,


### PR DESCRIPTION
## Proposed changes
### What changed
- Replaced raw environment string literals (`"local"`, `"dev"`, `"build"`, `"staging"`, `"integration"`) with the `ENVIRONMENTS` constant from `src/config/environments.ts` across source files.

### Why did it change
The `ENVIRONMENTS` constant already existed but wasn't used consistently.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing
All existing unit tests pass. No behaviour change: this is a pure refactor replacing string literals with their equivalent constant references.

## Checklist
- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
