### PR TITLE
feat(example-cri,document-builder): added alarm for heartbeat synthetic canary

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@
           name: Document Builder - Infrastructure static analysis
           language: system
           entry: bash -c 'cd document-builder && npm run checkov'
-          files: ^document-builder/template.yaml
+          files: ^document-builder/deploy/template.yaml
           stages: [pre-commit]
 
     - repo: local

--- a/document-builder/deploy/template.yaml
+++ b/document-builder/deploy/template.yaml
@@ -774,7 +774,7 @@ Resources:
       Dimensions:  
         - Name: CanaryName  
           Value: document_builder_heartbeat  
-      Period: 3600  # max evaluation period: 1 hour. The canary runs every 3 hours.
+      Period: 10800  # 3 hours in seconds, as the canary runs every 3 hours
       EvaluationPeriods: 1  
       Statistic: Maximum  
       ComparisonOperator: GreaterThanOrEqualToThreshold  

--- a/document-builder/deploy/template.yaml
+++ b/document-builder/deploy/template.yaml
@@ -761,30 +761,6 @@ Resources:
             Period: 60
             Stat: Minimum
 
-  ECRIHeartbeatAlarm:
-#    Condition: IsIntegration - to test in dev
-    Type: AWS::CloudWatch::Alarm  
-    Properties:
-      AlarmName: !Sub "${AWS::StackName}-ECRIHeartbeatAlarm"
-      AlarmDescription: "ExampleCRI-Heartbeat Synthetic-Canary Alarm: Failed  GreaterThanOrEqualToThreshold 1"
-      MetricName: Failed  
-      Namespace: CloudWatchSynthetics  
-      Dimensions:  
-        - Name: CanaryName  
-          Value: example_cri_heartbeat  
-      Period: 3600  # max evaluation period: 1 hour. The canary runs every 3 hours.
-      EvaluationPeriods: 1  
-      Statistic: Average  
-      ComparisonOperator: GreaterThanOrEqualToThreshold  
-      Threshold: 1.0  
-      TreatMissingData: notBreaching  
-      ActionsEnabled: true
-      AlarmActions:
-        - !ImportValue alarm-sns-topic-warning
-      OKActions:
-        - !ImportValue alarm-sns-topic-warning
-      InsufficientDataActions: []
-
 Outputs:
   DocBuilderFriendlyUrl:
     Description: Friendly URL for the deployed doc builder service

--- a/document-builder/deploy/template.yaml
+++ b/document-builder/deploy/template.yaml
@@ -761,6 +761,30 @@ Resources:
             Period: 60
             Stat: Minimum
 
+  ECRIHeartbeatAlarm:
+#    Condition: IsIntegration - to test in dev
+    Type: AWS::CloudWatch::Alarm  
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-ECRIHeartbeatAlarm"
+      AlarmDescription: "ExampleCRI-Heartbeat Synthetic-Canary Alarm: Failed  GreaterThanOrEqualToThreshold 1"
+      MetricName: Failed  
+      Namespace: CloudWatchSynthetics  
+      Dimensions:  
+        - Name: CanaryName  
+          Value: example_cri_heartbeat  
+      Period: 3600  # max evaluation period: 1 hour. The canary runs every 3 hours.
+      EvaluationPeriods: 1  
+      Statistic: Average  
+      ComparisonOperator: GreaterThanOrEqualToThreshold  
+      Threshold: 1.0  
+      TreatMissingData: notBreaching  
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue alarm-sns-topic-warning
+      OKActions:
+        - !ImportValue alarm-sns-topic-warning
+      InsufficientDataActions: []
+
 Outputs:
   DocBuilderFriendlyUrl:
     Description: Friendly URL for the deployed doc builder service

--- a/example-credential-issuer/deploy/template.yaml
+++ b/example-credential-issuer/deploy/template.yaml
@@ -840,7 +840,7 @@ Resources:
           Value: example_cri_heartbeat  
       Period: 3600  # max evaluation period: 1 hour. The canary runs every 3 hours.
       EvaluationPeriods: 1  
-      Statistic: Average  
+      Statistic: Maximum  
       ComparisonOperator: GreaterThanOrEqualToThreshold  
       Threshold: 1.0  
       TreatMissingData: notBreaching  
@@ -849,7 +849,6 @@ Resources:
         - !ImportValue alarm-sns-topic-warning
       OKActions:
         - !ImportValue alarm-sns-topic-warning
-      InsufficientDataActions: []
 
 Outputs:
   CredIssuerFriendlyUrl:

--- a/example-credential-issuer/deploy/template.yaml
+++ b/example-credential-issuer/deploy/template.yaml
@@ -828,7 +828,7 @@ Resources:
           Expression: (error/invocations) * 100
 
   ECRIHeartbeatAlarm:
-    Condition: IsIntegration - to test in dev
+    Condition: IsIntegration
     Type: AWS::CloudWatch::Alarm  
     Properties:
       AlarmName: !Sub "${AWS::StackName}-ECRIHeartbeatAlarm"

--- a/example-credential-issuer/deploy/template.yaml
+++ b/example-credential-issuer/deploy/template.yaml
@@ -825,6 +825,30 @@ Resources:
           ReturnData: false
           Expression: (error/invocations) * 100
 
+  ECRIHeartbeatAlarm:
+#    Condition: IsIntegration - to test in dev
+    Type: AWS::CloudWatch::Alarm  
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-ECRIHeartbeatAlarm"
+      AlarmDescription: "ExampleCRI-Heartbeat Synthetic-Canary Alarm: Failed  GreaterThanOrEqualToThreshold 1"
+      MetricName: Failed  
+      Namespace: CloudWatchSynthetics  
+      Dimensions:  
+        - Name: CanaryName  
+          Value: example_cri_heartbeat  
+      Period: 3600  # max evaluation period: 1 hour. The canary runs every 3 hours.
+      EvaluationPeriods: 1  
+      Statistic: Average  
+      ComparisonOperator: GreaterThanOrEqualToThreshold  
+      Threshold: 1.0  
+      TreatMissingData: notBreaching  
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue alarm-sns-topic-warning
+      OKActions:
+        - !ImportValue alarm-sns-topic-warning
+      InsufficientDataActions: []\
+      
 Outputs:
   CredIssuerFriendlyUrl:
     Description: Friendly URL for the deployed credential issuer service

--- a/example-credential-issuer/deploy/template.yaml
+++ b/example-credential-issuer/deploy/template.yaml
@@ -828,7 +828,7 @@ Resources:
           Expression: (error/invocations) * 100
 
   ECRIHeartbeatAlarm:
-    #Condition: IsIntegration
+    Condition: IsIntegration
     Type: AWS::CloudWatch::Alarm  
     Properties:
       AlarmName: !Sub "${AWS::StackName}-ECRIHeartbeatAlarm"
@@ -838,7 +838,7 @@ Resources:
       Dimensions:  
         - Name: CanaryName  
           Value: example_cri_heartbeat  
-      Period: 10800  # max evaluation period: 1 hour. The canary runs every 3 hours.
+      Period: 10800  # 3 hours in seconds
       EvaluationPeriods: 1  
       Statistic: Maximum  
       ComparisonOperator: GreaterThanOrEqualToThreshold  

--- a/example-credential-issuer/deploy/template.yaml
+++ b/example-credential-issuer/deploy/template.yaml
@@ -46,6 +46,8 @@ Conditions:
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]
 
+  IsIntegration: !Equals [!Ref Environment, integration]
+
   UsePermissionsBoundary:
     Fn::Not:
       - Fn::Equals:
@@ -826,7 +828,7 @@ Resources:
           Expression: (error/invocations) * 100
 
   ECRIHeartbeatAlarm:
-#    Condition: IsIntegration - to test in dev
+    Condition: IsIntegration - to test in dev
     Type: AWS::CloudWatch::Alarm  
     Properties:
       AlarmName: !Sub "${AWS::StackName}-ECRIHeartbeatAlarm"

--- a/example-credential-issuer/deploy/template.yaml
+++ b/example-credential-issuer/deploy/template.yaml
@@ -847,8 +847,8 @@ Resources:
         - !ImportValue alarm-sns-topic-warning
       OKActions:
         - !ImportValue alarm-sns-topic-warning
-      InsufficientDataActions: []\
-      
+      InsufficientDataActions: []
+
 Outputs:
   CredIssuerFriendlyUrl:
     Description: Friendly URL for the deployed credential issuer service

--- a/example-credential-issuer/deploy/template.yaml
+++ b/example-credential-issuer/deploy/template.yaml
@@ -828,7 +828,7 @@ Resources:
           Expression: (error/invocations) * 100
 
   ECRIHeartbeatAlarm:
-    Condition: IsIntegration
+    #Condition: IsIntegration
     Type: AWS::CloudWatch::Alarm  
     Properties:
       AlarmName: !Sub "${AWS::StackName}-ECRIHeartbeatAlarm"
@@ -838,7 +838,7 @@ Resources:
       Dimensions:  
         - Name: CanaryName  
           Value: example_cri_heartbeat  
-      Period: 3600  # max evaluation period: 1 hour. The canary runs every 3 hours.
+      Period: 10800  # max evaluation period: 1 hour. The canary runs every 3 hours.
       EvaluationPeriods: 1  
       Statistic: Maximum  
       ComparisonOperator: GreaterThanOrEqualToThreshold  

--- a/example-credential-issuer/deploy/template.yaml
+++ b/example-credential-issuer/deploy/template.yaml
@@ -838,7 +838,7 @@ Resources:
       Dimensions:  
         - Name: CanaryName  
           Value: example_cri_heartbeat  
-      Period: 10800  # 3 hours in seconds
+      Period: 10800  # 3 hours in seconds, as the canary runs every 3 hours
       EvaluationPeriods: 1  
       Statistic: Maximum  
       ComparisonOperator: GreaterThanOrEqualToThreshold  


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->

A synthetic canary has been deployed to Int (and dev for testing) by use of click-ops. This alarm is triggered when the canary fails.

The canary:
- hits this url (https://example-credential-issuer.wallet-onboarding.{ENV}.account.gov.uk/.well-known/openid-credential-issuer) and expects a 200 response
- hits the url every 3 hours Mon-Fri

The alarm:
- is triggered when failure count is equal or greater than '1'
- has an evaluation period of 10800 secs (3 hours)
- send a message, via sns, to slack warning channel

Misc: 
- the pre-commit config for doc-builder has been amended to have the correct path.
- extended the alarm period on the doc builder to 3 hours.

### Why did it change
<!-- Describe the reason these changes were made -->

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-20384](https://govukverify.atlassian.net/browse/DCMAW-20384)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

Alarm in Slack after test deploy in dev:

<img width="782" height="410" alt="V CloudWatch Alarm  wallet-cred-Issuer-ECRIHeartbeatAlarm  eu-west-2  Account)" src="https://github.com/user-attachments/assets/5499b0f3-6175-4583-b7ed-df449ea9798e" />

Test alarm deployed to dev:

<img width="1130" height="600" alt="image" src="https://github.com/user-attachments/assets/38402cde-da1b-480e-8c9f-082645035153" />

Canary in Int:

<img width="1388" height="167" alt="image" src="https://github.com/user-attachments/assets/ba78ba01-b902-47a4-bf8e-9fda25f94929" />


## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-20384]: https://govukverify.atlassian.net/browse/DCMAW-20384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ